### PR TITLE
Use CryptographicOperations.FixedTimeEquals to compare hashes

### DIFF
--- a/src/CSharp/CommonAnnotatedSecurityKeys/Cask.cs
+++ b/src/CSharp/CommonAnnotatedSecurityKeys/Cask.cs
@@ -242,26 +242,7 @@ namespace CommonAnnotatedSecurityKeys
         public bool CompareHash(byte[] candidateHash, byte[] derivationInput, byte[] secret, int secretEntropyInBytes)
         {
             byte[] computedHash = GenerateHashedSignatureBytes(derivationInput, secret, secretEntropyInBytes);
-
-            if (computedHash.Length != candidateHash.Length)
-            {
-                return false;
-            }
-
-            bool matched = true;
-            for (int i = 0; i < computedHash.Length; i++)
-            {
-                // We will complete a full comparison of all the data
-                // so that timing differences do not leak information
-                // to an upstream caller (i.e., how much of the hash
-                // matched before we observed a discrepancy).
-                if (computedHash[i] != candidateHash[i])
-                {
-                    matched = false;
-                }
-            }
-
-            return matched;
+            return CryptographicOperations.FixedTimeEquals(computedHash, candidateHash);
         }
     }
 }

--- a/src/CSharp/CommonAnnotatedSecurityKeys/Polyfill/CryptographicOperations.cs
+++ b/src/CSharp/CommonAnnotatedSecurityKeys/Polyfill/CryptographicOperations.cs
@@ -54,7 +54,6 @@ namespace System.Security.Cryptography
 
             return accum == 0;
         }
-
     }
 }
 #endif

--- a/src/CSharp/CommonAnnotatedSecurityKeys/Polyfill/CryptographicOperations.cs
+++ b/src/CSharp/CommonAnnotatedSecurityKeys/Polyfill/CryptographicOperations.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// WARNING: DO NOT MODIFY EXCEPT TO UPDATE TO A LATER VERSION OF THE CODE FROM THE BCL. THIS IS HARDER THAN IT MAY SEEM TO GET RIGHT!
+// Source: https://github.com/dotnet/runtime/blob/354ec46a63440608bda18e2203bb5538e2f8eae6/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptographicOperations.cs
+
+#if NETFRAMEWORK
+using System.Runtime.CompilerServices;
+
+namespace System.Security.Cryptography
+{    
+    internal static class CryptographicOperations
+    {
+        /// <summary>
+        /// Determine the equality of two byte sequences in an amount of time which depends on
+        /// the length of the sequences, but not the values.
+        /// </summary>
+        /// <param name="left">The first buffer to compare.</param>
+        /// <param name="right">The second buffer to compare.</param>
+        /// <returns>
+        ///   <c>true</c> if <paramref name="left"/> and <paramref name="right"/> have the same
+        ///   values for <see cref="ReadOnlySpan{T}.Length"/> and the same contents, <c>false</c>
+        ///   otherwise.
+        /// </returns>
+        /// <remarks>
+        ///   This method compares two buffers' contents for equality in a manner which does not
+        ///   leak timing information, making it ideal for use within cryptographic routines.
+        ///   This method will short-circuit and return <c>false</c> only if <paramref name="left"/>
+        ///   and <paramref name="right"/> have different lengths.
+        ///
+        ///   Fixed-time behavior is guaranteed in all other cases, including if <paramref name="left"/>
+        ///   and <paramref name="right"/> reference the same address.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        public static bool FixedTimeEquals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+        {
+            // NoOptimization because we want this method to be exactly as non-short-circuiting
+            // as written.
+            //
+            // NoInlining because the NoOptimization would get lost if the method got inlined.
+
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            int length = left.Length;
+            int accum = 0;
+
+            for (int i = 0; i < length; i++)
+            {
+                accum |= left[i] - right[i];
+            }
+
+            return accum == 0;
+        }
+
+    }
+}
+#endif


### PR DESCRIPTION
This sort of thing was new to me so I chatted with Levi about it to learn more when I saw it. He alerted me to the fact that our implementation was incorrect. 😀

Fixing it, and using this PR as an opportunity to discuss the [polyfill](https://en.wikipedia.org/wiki/Polyfill_(programming)) pattern for .NET Framework that I'm effectively proposing here. I suspect I'm going to need more of this as I go through all the things I've promised to do so it will be good to decide now if we want to do this any differently.
