### PR TITLE
Initial skeleton code for C++ Implementation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,17 +4,15 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 2
-
-# .gitattributes is configured to make this work on Windows too, irrespective of git config
-end_of_line = lf
 insert_final_newline = true
 
-[*.sln]
-end_of_line = crlf
-charset = utf-8-bom
+# *WARNING*: If you use the Visual Studio Designer to edit this file, it may
+# change this to 'crlf'. Revert it back to 'unset' or x-plat things will
+# break.
+end_of_line = unset
 
-[*.lutconfig]
-end_of_line = crlf
+[*.sln]
+charset = utf-8-bom
 
 #### C# Coding Conventions ####
 [*.cs]
@@ -171,6 +169,9 @@ dotnet_diagnostic.CA1303.severity = silent
 
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.CS1591.severity = silent
+
+# IDE0072: Add missing cases
+dotnet_diagnostic.IDE0072.severity = silent
 
 [*.{cs,vb}]
 #### .NET Coding Conventions ####
@@ -424,3 +425,76 @@ dotnet_naming_style.s_camelcase.capitalization = camel_case
 
 dotnet_style_allow_multiple_blank_lines_experimental = true:silent
 dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+
+### C++ Coding Conventions ###  
+[*.{c,c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
+indent_size = 4
+cpp_generate_documentation_comments = xml
+cpp_indent_braces = false
+cpp_indent_multi_line_relative_to = statement_begin
+cpp_indent_within_parentheses = indent
+cpp_indent_preserve_within_parentheses = true
+cpp_indent_case_contents = false
+cpp_indent_case_labels = false
+cpp_indent_case_contents_when_block = false
+cpp_indent_lambda_braces_when_parameter = false
+cpp_indent_goto_labels = none
+cpp_indent_preprocessor = none
+cpp_indent_access_specifiers = false
+cpp_indent_namespace_contents = false
+cpp_indent_preserve_comments = false
+cpp_new_line_before_open_brace_namespace = ignore
+cpp_new_line_before_open_brace_type = ignore
+cpp_new_line_before_open_brace_function = ignore
+cpp_new_line_before_open_brace_block = ignore
+cpp_new_line_before_open_brace_lambda = ignore
+cpp_new_line_scope_braces_on_separate_lines = false
+cpp_new_line_close_brace_same_line_empty_type = true
+cpp_new_line_close_brace_same_line_empty_function = true
+cpp_new_line_before_catch = false
+cpp_new_line_before_else = false
+cpp_new_line_before_while_in_do_while = false
+cpp_space_before_function_open_parenthesis = ignore
+cpp_space_within_parameter_list_parentheses = false
+cpp_space_between_empty_parameter_list_parentheses = false
+cpp_space_after_keywords_in_control_flow_statements = true
+cpp_space_within_control_flow_statement_parentheses = false
+cpp_space_before_lambda_open_parenthesis = false
+cpp_space_within_cast_parentheses = false
+cpp_space_after_cast_close_parenthesis = false
+cpp_space_within_expression_parentheses = false
+cpp_space_before_block_open_brace = false
+cpp_space_between_empty_braces = false
+cpp_space_before_initializer_list_open_brace = false
+cpp_space_within_initializer_list_braces = false
+cpp_space_preserve_in_initializer_list = false
+cpp_space_before_open_square_bracket = false
+cpp_space_within_square_brackets = false
+cpp_space_before_empty_square_brackets = false
+cpp_space_between_empty_square_brackets = false
+cpp_space_group_square_brackets = false
+cpp_space_within_lambda_brackets = false
+cpp_space_between_empty_lambda_brackets = false
+cpp_space_before_comma = false
+cpp_space_after_comma = true
+cpp_space_remove_around_member_operators = false
+cpp_space_before_inheritance_colon = false
+cpp_space_before_constructor_colon = false
+cpp_space_remove_before_semicolon = false
+cpp_space_after_semicolon = false
+cpp_space_remove_around_unary_operator = false
+cpp_space_around_binary_operator = ignore
+cpp_space_around_assignment_operator = ignore
+cpp_space_pointer_reference_alignment = ignore
+cpp_space_around_ternary_operator = ignore
+cpp_use_unreal_engine_macro_formatting = false
+cpp_wrap_preserve_blocks = never
+cpp_include_cleanup_add_missing_error_tag_type = suggestion
+cpp_include_cleanup_remove_unused_error_tag_type = dimmed
+cpp_include_cleanup_optimize_unused_error_tag_type = suggestion
+cpp_include_cleanup_sort_after_edits = false
+cpp_sort_includes_error_tag_type = none
+cpp_sort_includes_priority_case_sensitive = false
+cpp_sort_includes_priority_style = quoted
+cpp_includes_style = default
+cpp_includes_use_forward_slash = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,5 @@
-# Use unix line endings always, even on Windows
-*                            text=auto eol=lf
-
-# Exceptions to above for files that VS saves with CRLF always
-*.sln                        eol=crlf
-*.lutconfig                  eol=crlf
+# Normalize line endings to LF in repo, checkout CRLF on Windows
+*                            text=auto
 
 # Allow comments in JSON in GitHub rendering
 *.json                       linguist-language=JSON-with-Comments

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
       run: dotnet restore src
 
     - name: Check Formatting
-      run: dotnet format --verify-no-changes src
+      run: dotnet format --verify-no-changes src --verbosity diagnostic
 
     - name: Build
       run: dotnet build src -c ${{matrix.configuration}} --no-restore

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,6 @@
   "editor.insertSpaces": true,
   "editor.tabSize": 2,
   "files.encoding": "utf8",
-  "files.eol": "\n",
   "files.insertFinalNewline": true,
   "files.exclude": {
     "bld/**": true,

--- a/src/Cask.sln
+++ b/src/Cask.sln
@@ -16,6 +16,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{0C3A2105-9369-461A-92AB-3D39CA120B83}"
 	ProjectSection(SolutionItems) = preProject
 		..\.editorconfig = ..\.editorconfig
+		..\.gitattributes = ..\.gitattributes
+		..\.gitignore = ..\.gitignore
 		Cask.lutconfig = Cask.lutconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.rsp = Directory.Build.rsp
@@ -51,6 +53,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Workflows", "Workflows", "{
 		..\.github\workflows\validate.yml = ..\.github\workflows\validate.yml
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libcask", "libcask\libcask.vcxproj", "{14013CD3-B963-4851-AA9A-7C7A2F110A52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +77,8 @@ Global
 		{FB74046B-2FF6-4316-85B1-39A28D945A18}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB74046B-2FF6-4316-85B1-39A28D945A18}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB74046B-2FF6-4316-85B1-39A28D945A18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14013CD3-B963-4851-AA9A-7C7A2F110A52}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{14013CD3-B963-4851-AA9A-7C7A2F110A52}.Release|Any CPU.ActiveCfg = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Tests/Cask.Tests/Cask.Tests.csproj
+++ b/src/Tests/Cask.Tests/Cask.Tests.csproj
@@ -1,9 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <OSIsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</OSIsWindows>
+    <OSIsX64 Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64'">true</OSIsX64>
+    <MSBuildIsNETFramework Condition="'$(MSBuildRuntimeType)' == 'full'">true</MSBuildIsNETFramework>
+    <BuildCpp Condition="'$(OSIsWindows)' == 'true' and '$(MSBuildIsNETFramework)' == 'true' and '$(OSIsX64)' == 'true'">true</BuildCpp>
+    <!-- TODO: Our custom C++ build logic is breaking fast-up-to-date for this project. -->
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
+    <EnableUnmanagedDebugging>true</EnableUnmanagedDebugging>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\Cask\Cask.csproj" />
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(BuildCpp)' == 'true'">
+    <CppProjectReference Include="..\..\libcask\libcask.vcxproj" Properties="Platform=x64" />
+    <Content Include="$(ArtifactsPath)\bin\libcask\$(Configuration.ToLowerInvariant())_x64\libcask.dll" CopyToOutputDirectory="PreserveNewest" Visible="false" />
+    <AssemblyMetadata Include="BuiltWithCppSupport" Value="true" />
+  </ItemGroup>
+
+  <Target Name="BuildCppProjectReference" BeforeTargets="DispatchToInnerBuilds">
+    <MSBuild Projects="@(CppProjectReference)" />
+  </Target>
+
+  <Target Name="CleanCppProjectReference" BeforeTargets="Clean" Condition="'$(TargetFramework)' == ''">
+    <MSBuild Projects="@(CppProjectReference)" Targets="Clean" />
+  </Target>
+
 </Project>

--- a/src/Tests/Cask.Tests/Cask.Tests.csproj
+++ b/src/Tests/Cask.Tests/Cask.Tests.csproj
@@ -21,7 +21,7 @@
     <AssemblyMetadata Include="BuiltWithCppSupport" Value="true" />
   </ItemGroup>
 
-  <Target Name="BuildCppProjectReference" BeforeTargets="DispatchToInnerBuilds">
+  <Target Name="BuildCppProjectReference" BeforeTargets="DispatchToInnerBuilds" Condition="'$(InnerTargets)' == 'Build'">
     <MSBuild Projects="@(CppProjectReference)" />
   </Target>
 

--- a/src/Tests/Cask.Tests/CppCaskTests.cs
+++ b/src/Tests/Cask.Tests/CppCaskTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+using Xunit;
+
+using static System.Runtime.InteropServices.UnmanagedType;
+
+// CA2101: Specify marshaling for P/Invoke string arguments Supppressed due to
+// false positives: https://github.com/dotnet/roslyn-analyzers/issues/7502
+#pragma warning disable CA2101
+
+// SYSLIB1054: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to
+// generate P/Invoke marshalling code at compile time This is very cool but
+// would require additional work to switch between LibraryImport and DllImport
+// based on target framework.
+#pragma warning disable SYSLIB1054
+
+// CA5393: Use of unsafe DllImportSearchPath value UseDllDirectoryForDependencies
+// DLL fails to load on .NET Framework without it since TestHost application directory
+// is not the same directory as the test assembly.
+#pragma warning disable CA5393
+
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories | DllImportSearchPath.UseDllDirectoryForDependencies)]
+
+namespace CommonAnnotatedSecurityKeys.Tests;
+
+// WIP: These tests are disabled because the C++ implementation is stubbed out.
+//      To enable them, flip the return value of IsSupportedTestClass in
+//      TestFilter.cs.
+
+public class CppCaskTests : CaskTestsBase
+{
+    public CppCaskTests() : base(new Implementation())
+    {
+    }
+
+    private sealed class Implementation : ICask
+    {
+        public bool CompareHash(string candidateHash,
+                                byte[] derivationInput,
+                                string secret,
+                                int secretEntropyInBytes = 32)
+        {
+            return NativeMethods.Cask_CompareHash(candidateHash, derivationInput, derivationInput.Length, secret, secretEntropyInBytes);
+        }
+
+        public string GenerateHash(byte[] derivationInput,
+                                   string secret,
+                                   int secretEntropyInBytes = 32)
+        {
+            int size = NativeMethods.Cask_GenerateHash(derivationInput, derivationInput.Length, secret, secretEntropyInBytes, null, 0);
+            byte[] bytes = new byte[size];
+            size = NativeMethods.Cask_GenerateHash(derivationInput, derivationInput.Length, secret, secretEntropyInBytes, bytes, size);
+            Assert.True(size == bytes.Length, "Cask_GenerateKey did not use as many bytes as it said it would.");
+            return Encoding.UTF8.GetString(bytes, 0, size - 1); // - 1 to remove null terminator
+        }
+
+        public string GenerateKey(string providerSignature,
+                                  string allocatorCode,
+                                  string? reserved = null,
+                                  int secretEntropyInBytes = 32)
+        {
+            int size = NativeMethods.Cask_GenerateKey(providerSignature, allocatorCode, reserved, secretEntropyInBytes, null, 0);
+            byte[] bytes = new byte[size];
+            size = NativeMethods.Cask_GenerateKey(providerSignature, allocatorCode, reserved, secretEntropyInBytes, bytes, size);
+            Assert.True(size == bytes.Length, "Cask_GenerateKey did not use as many bytes as it said it would.");
+            return Encoding.UTF8.GetString(bytes, 0, size - 1); // -1 to remove null terminator
+        }
+
+        public bool IsCask(string keyOrHash)
+        {
+            return NativeMethods.Cask_IsCask(keyOrHash);
+        }
+
+        public bool IsCaskBytes(byte[] bytes)
+        {
+            return NativeMethods.Cask_IsCaskBytes(bytes, bytes.Length);
+        }
+
+        Mock ICask.MockFillRandom(FillRandomAction fillRandom)
+        {
+            throw new NotImplementedException();
+        }
+
+        Mock ICask.MockUtcNow(UtcNowFunc getUtcNow)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static class NativeMethods
+        {
+            [DllImport("libcask")]
+            [return: MarshalAs(I1)]
+            public static extern bool Cask_IsCask(
+                [MarshalAs(LPUTF8Str)] string keyOrHash);
+
+            [DllImport("libcask")]
+            [return: MarshalAs(I1)]
+            public static extern bool Cask_IsCaskBytes(
+                byte[] keyOrHash,
+                int length);
+
+            [DllImport("libcask")]
+            [return: MarshalAs(I1)]
+            public static extern bool Cask_CompareHash(
+                [MarshalAs(LPUTF8Str)]
+                string candidateHash,
+                byte[] derivationInput,
+                int derivationInputLength,
+                [MarshalAs(LPUTF8Str)] string secret,
+                int secretEntropyInBytes);
+
+            [DllImport("libcask")]
+            public static extern int Cask_GenerateKey(
+                [MarshalAs(LPUTF8Str)]
+                string providerSignature,
+                [MarshalAs(LPUTF8Str)]
+                string allocatorCode,
+                [MarshalAs(LPUTF8Str)]
+                string? providerData,
+                int secretEntropyInBytes,
+                byte[]? output,
+                int outputCapacity);
+
+            [DllImport("libcask")]
+            public static extern int Cask_GenerateHash(
+                byte[] derivationInput,
+                int derivationInputLength,
+                [MarshalAs(LPUTF8Str)]
+                string secret,
+                int secretEntropyInBytes,
+                byte[]? output,
+                int outputCapacity);
+        }
+    }
+}
+

--- a/src/Tests/Cask.Tests/Properties/launchSettings.json
+++ b/src/Tests/Cask.Tests/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Cask.Tests": {
+      "commandName": "Project",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/src/Tests/Cask.Tests/TestFilter.cs
+++ b/src/Tests/Cask.Tests/TestFilter.cs
@@ -52,6 +52,7 @@ public sealed class TestFilter : XunitTestFramework
 
         return true;
     }
+
     private static bool BuiltWithCppSupport()
     {
         foreach (AssemblyMetadataAttribute attribute in Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyMetadataAttribute>())

--- a/src/Tests/Cask.Tests/TestFilter.cs
+++ b/src/Tests/Cask.Tests/TestFilter.cs
@@ -14,6 +14,8 @@ namespace CommonAnnotatedSecurityKeys.Tests;
 
 public sealed class TestFilter : XunitTestFramework
 {
+    private static readonly bool s_builtWithCppSupport = IsBuiltWithCppSupport();
+
     public TestFilter(IMessageSink messageSink) : base(messageSink) { }
 
     protected override ITestFrameworkDiscoverer CreateDiscoverer(IAssemblyInfo assemblyInfo)
@@ -37,7 +39,7 @@ public sealed class TestFilter : XunitTestFramework
                 return false;
             }
 
-            if (!BuiltWithCppSupport())
+            if (!s_builtWithCppSupport)
             {
                 Console.WriteLine("INFO: Skipping C++ tests because the test assembly was not built with C++ support.");
                 Console.WriteLine("      Use Visual Studio or `msbuild` to build with C++ support.");
@@ -53,7 +55,7 @@ public sealed class TestFilter : XunitTestFramework
         return true;
     }
 
-    private static bool BuiltWithCppSupport()
+    private static bool IsBuiltWithCppSupport()
     {
         foreach (AssemblyMetadataAttribute attribute in Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyMetadataAttribute>())
         {

--- a/src/Tests/Cask.Tests/TestFilter.cs
+++ b/src/Tests/Cask.Tests/TestFilter.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: TestFramework("CommonAnnotatedSecurityKeys.Tests.TestFilter", "Cask.Tests")]
+
+namespace CommonAnnotatedSecurityKeys.Tests;
+
+public sealed class TestFilter : XunitTestFramework
+{
+    public TestFilter(IMessageSink messageSink) : base(messageSink) { }
+
+    protected override ITestFrameworkDiscoverer CreateDiscoverer(IAssemblyInfo assemblyInfo)
+    {
+        return new Discoverer(assemblyInfo, SourceInformationProvider, DiagnosticMessageSink);
+    }
+
+    private static bool IsSupportedTestClass(ITypeInfo type)
+    {
+        if (type.Name.EndsWith($".{nameof(CppCaskTests)}", StringComparison.Ordinal))
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Console.WriteLine("INFO: Skipping C++ tests on non-Windows.");
+                return false;
+            }
+
+            if (RuntimeInformation.OSArchitecture != Architecture.X64)
+            {
+                Console.WriteLine("INFO: Skipping C++ tests on non-x64 OS.");
+                return false;
+            }
+
+            if (!BuiltWithCppSupport())
+            {
+                Console.WriteLine("INFO: Skipping C++ tests because the test assembly was not built with C++ support.");
+                Console.WriteLine("      Use Visual Studio or `msbuild` to build with C++ support.");
+                return false;
+            }
+
+            // WIP: Flip this to true to enable C++ tests. They are not yet
+            //      enabled because they fail as the C++ implementation is
+            //      stubbed out..
+            return false;
+        }
+
+        return true;
+    }
+    private static bool BuiltWithCppSupport()
+    {
+        foreach (AssemblyMetadataAttribute attribute in Assembly.GetExecutingAssembly().GetCustomAttributes<AssemblyMetadataAttribute>())
+        {
+            if (attribute.Key == "BuiltWithCppSupport")
+            {
+                return attribute.Value == "true";
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class Discoverer : XunitTestFrameworkDiscoverer
+    {
+        public Discoverer(
+            IAssemblyInfo assemblyInfo,
+            ISourceInformationProvider sourceProvider,
+            IMessageSink diagnosticMessageSink,
+            IXunitTestCollectionFactory? collectionFactory = null)
+            : base(assemblyInfo, sourceProvider, diagnosticMessageSink, collectionFactory) { }
+
+        protected override bool IsValidTestClass(ITypeInfo type)
+        {
+            return base.IsValidTestClass(type) && IsSupportedTestClass(type);
+        }
+    }
+}

--- a/src/Tests/Cask.Tests/xunit.runner.json
+++ b/src/Tests/Cask.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false
+}

--- a/src/libcask/.gitignore
+++ b/src/libcask/.gitignore
@@ -1,0 +1,1 @@
+libcask.sln

--- a/src/libcask/.gitignore
+++ b/src/libcask/.gitignore
@@ -1,1 +1,0 @@
-libcask.sln

--- a/src/libcask/cask.cpp
+++ b/src/libcask/cask.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// WIP: This file implements the interop-friendly libcask API
+//      The implementation can use C++.
+
+#include <string.h>
+
+#include "cask.h"
+#include "cask_dependencies.h"
+
+CASK_API bool Cask_IsCask(const char* keyOrHash)
+{
+    return false;
+}
+
+CASK_API bool Cask_IsCaskBytes(const uint8_t* keyOrHashBytes,
+                               int32_t length)
+{
+     return false; 
+}
+
+CASK_API int32_t Cask_GenerateKey(const char* allocatorCode,
+                                  const char* providerSignature,
+                                  const char* providerData,
+                                  int32_t secretEntropyInBytes,
+                                  char* output,
+                                  int32_t outputSizeInBytes)
+{
+    // WIP: Demonstrating a calling pattern for caller to be able to ask for
+    //      buffer size. We can mimic this in GenerateHash. This is always a
+    //      challenge for C API and I'm open to other approaches.
+
+    const char* key = "not_a_real_key";
+    int32_t requiredSizeInBytes = int32_t(strlen(key) + 1); // +1 for null terminator
+
+    if (output == nullptr)
+    {
+        // no buffer: return the minimum size of the buffer needed to succeed.
+        // caller can then allocate a buffer of that size and call again.
+        return requiredSizeInBytes;
+    }
+
+    if (outputSizeInBytes < requiredSizeInBytes)
+    {
+        // buffer is too small: return 0
+        return 0;
+    }
+
+    // buffer is big enough: write to buffer and return the number of bytes written
+    strncpy_s(output, outputSizeInBytes, key, requiredSizeInBytes);
+    return requiredSizeInBytes;
+}
+
+CASK_API int32_t Cask_GenerateHash(const uint8_t* derivationInputBytes,
+                                   const int32_t derivationInputLength,
+                                   const char* secret,
+                                   int32_t secretEntropyInBytes,
+                                   char* buffer,
+                                   int32_t bufferSize)
+{
+    return 0;
+}
+
+CASK_API bool Cask_CompareHash(const char* candidateHash,
+                               const uint8_t* derivationInputBytes,
+                               const int32_t derivationInputLength,
+                               const char* secret,
+                               int32_t secretEntropyInBytes)
+{
+    return false;
+}
+

--- a/src/libcask/cask.h
+++ b/src/libcask/cask.h
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// WIP: This header wil define the interop-friendly libcask API that will be
+//      exported from .dll/.so. This surface area must remain C compatible and
+//      cannot use C++-only types and features
+
+#ifndef CASK_H
+#define CASK_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+#define CASK_EXTERN_C extern "C"
+#else
+#define CASK_EXTERN_C
+#endif
+
+#ifdef LIBCASK_EXPORTS
+#define CASK_API CASK_EXTERN_C __declspec(dllexport)
+#else
+#define CASK_API CASK_EXTERN_C __declspec(dllimport)
+#endif
+
+CASK_API bool Cask_IsCask(const char* keyOrHash);
+
+CASK_API bool Cask_IsCaskBytes(const uint8_t* keyOrHashBytes,
+                               int32_t length);
+
+CASK_API int32_t Cask_GenerateKey(const char* allocatorCode,
+                                  const char* providerSignature,
+                                  const char* providerData,
+                                  int32_t secretEntropyInBytes,
+                                  char* buffer,
+                                  int32_t bufferSize);
+
+CASK_API int32_t Cask_GenerateHash(const uint8_t* derivationInputBytes,
+                                   const int32_t derivationInputLength,
+                                   const char* secret,
+                                   int32_t secretEntropyInBytes,
+                                   char* buffer,
+                                   int32_t bufferSize);
+
+CASK_API bool Cask_CompareHash(const char* candidateHash,
+                               const uint8_t* derivationInputBytes,
+                               const int32_t derivationInputLength,
+                               const char* secret,
+                               int32_t secretEntropyInBytes);
+
+#endif // CASK_H

--- a/src/libcask/cask_cimport_test.c
+++ b/src/libcask/cask_cimport_test.c
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Dummy file to validate cask.h can be #included from C
+#include "cask.h"

--- a/src/libcask/cask_dependencies.cpp
+++ b/src/libcask/cask_dependencies.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// WIP: This is our reference implementation for dependencies. We can pull in
+//      external libraries of our choice here and only here. We can use C++
+//      here.
+
+#include "cask_dependencies.h"
+
+std::string Cask::Base64UrlEncode(const std::span<uint8_t>& bytes)
+{
+    return "";
+}
+
+int32_t Cask::ComputeCrc32(const std::span<uint8_t>& bytes)
+{
+    return 0;
+}

--- a/src/libcask/cask_dependencies.h
+++ b/src/libcask/cask_dependencies.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// WIP: This header will define a facade over all dependencies that libcask has
+//      that are not provided by the C++ standard library. Our reference
+//      implementation will choose external depenencies to implement this.
+//      Someone can then take the reference source implementation and
+//      replace/edit cask_dependencies.cpp. We can use C++ here.
+
+#include <cstdint>
+#include <string>
+#include <span>
+
+namespace Cask {
+
+std::string Base64UrlEncode(const std::span<uint8_t>& bytes);
+int32_t ComputeCrc32(const std::span<uint8_t>& bytes);
+
+} // namespace Cask

--- a/src/libcask/libcask.vcxproj
+++ b/src/libcask/libcask.vcxproj
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{14013cd3-b963-4851-aa9a-7c7a2f110a52}</ProjectGuid>
+    <RootNamespace>libcask</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)..\bld\bin\$(ShortProjectName)\release_x64\</OutDir>
+    <IntDir>$(SolutionDir)..\bld\obj\$(ShortProjectName)\release_x64\/</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)..\bld\bin\$(ShortProjectName)\debug_x64\</OutDir>
+    <IntDir>$(SolutionDir)..\bld\obj\$(ShortProjectName)\debug_x64\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;LIBCASK_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;LIBCASK_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="cask.h" />
+    <ClInclude Include="cask_dependencies.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="cask.cpp" />
+    <ClCompile Include="cask_dependencies.cpp" />
+    <ClCompile Include="cask_cimport_test.c" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/xunit.runner.json
+++ b/src/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false
+}


### PR DESCRIPTION
* Add libcask native dll project to solution
* Add stub implementation aligned to test ICask interface
* Add P/Invoke interop in tests
* Use MSBuild and Xunit magic so that we
  1. Have a good experience in VS on Windows for C++
  2. Don't regress the C# dev experience x-plat for C#

The focus here is on getting the build off the ground so folks can work in parallel. The API shape will surely change when an actual non-stub C++ implementation is worked on.

This currently works only on Windows x64 and only with big VS, but everything is set up there to the point where you can drop a breakpoint in .cpp and hit it from the Test Explorer.

More work will be needed to match this experience for Linux, Mac, VS Code on Windows, and non-x64 architectures.

There is also no PR validation coverage yet because that will require infrastructure to build with big VS and/or solving x-plat.

### Also (not strictly related)
* Revert back to CRLF on Windows

There are too many issues with VS putting snippets with CRLF into files and making them have mixed line endings.