### PR TITLE
build: fix dotnet test on certain 9.0.200-preview builds

### DIFF
--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="..\Directory.Build.props" />
 
   <ItemGroup Label="Common Test-Only Dependencies" Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="xunit" />
   </ItemGroup>


### PR DESCRIPTION
For a period, there was breaking SDK change with `PrivateAssets="all"` stripping things from the build `deps.json`. It's been [reverted](https://github.com/dotnet/sdk/pull/46182) but that revert hasn't made it to preview builds of VS yet.

While this breaking change is around, having a `PrivateAssets="all"` reference to `Microsoft.NET.Test.Sdk` causes:

```
Testhost process for source(s) 'D:\Src\cask\bld\bin\Cask.Tests\debug_net8.0\Cask.Tests.dll' exited with error: Unhandled exception.
System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.`
```

There's no real reason for our `Microsoft.NET.Test.Sdk` reference to have `PrivateAssets="all"` and removing it works around the issue, so this change removes it.