### PR TITLE
Provider key kind as char.

### DIFF
--- a/src/Cask.Cli/GenerateCommand.cs
+++ b/src/Cask.Cli/GenerateCommand.cs
@@ -23,8 +23,7 @@ internal static class GenerateCommand
 
         for (int i = 0; i < options.Count; i++)
         {
-            CaskKey key = Cask.GenerateKey(providerSignature, providerData);
-
+            CaskKey key = Cask.GenerateKey(providerSignature, 'A', 0, providerData);
             string validity = Cask.IsCask(key.ToString()) ? "Valid Key   " : "INVALID KEY ";
             Console.WriteLine($"{validity}: {key}");
         }

--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -220,9 +220,9 @@ public static class Cask
         Debug.Assert(bytesWritten == providerData.Length / 4 * 3);
     }
 
-    public static void ComputeExpiryChars(int expiryInFiveMinuteIncrements, Span<char> destination)
+    private static void ComputeExpiryChars(int expiryInFiveMinuteIncrements, Span<char> destination)
     {
-        ThrowIfDestinationTooSmall(destination, 3);
+        Debug.Assert(destination.Length == 3);
         ValidateExpiry(expiryInFiveMinuteIncrements);
 
         Span<char> expiryChars = stackalloc char[4];

--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -138,11 +138,10 @@ public static class Cask
     }
 
     public static CaskKey GenerateKey(string providerSignature,
-                                      string providerKeyKind,
+                                      char providerKeyKind,
                                       int expiryInFiveMinuteIncrements = 0,
                                       string? providerData = null)
     {
-        providerKeyKind ??= $"{Base64UrlChars[0]}"; // "A", i.e., index 0 of all base64-encoded characters.
         providerData ??= string.Empty;
 
         ValidateProviderSignature(providerSignature);
@@ -269,18 +268,11 @@ public static class Cask
             ThrowIllegalUrlSafeBase64(providerSignature);
         }
     }
-    private static void ValidateProviderKeyKind(string providerKeyKind)
+    private static void ValidateProviderKeyKind(char providerKeyKind)
     {
-        ThrowIfNull(providerKeyKind);
-
-        if (providerKeyKind.Length != 1)
-        {
-            ThrowLengthNotEqual(providerKeyKind, 1);
-        }
-
         if (!IsValidForBase64Url(providerKeyKind))
         {
-            ThrowIllegalUrlSafeBase64(providerKeyKind);
+            ThrowIllegalUrlSafeBase64(providerKeyKind.ToString());
         }
     }
 

--- a/src/Cask/Helpers.cs
+++ b/src/Cask/Helpers.cs
@@ -73,8 +73,8 @@ internal static class Helpers
     {
         int base64Index;
 
-        const int uppercaseZIndex = 25; // 'Z' - 'A';
-        const int lowercaseZIndex = 51; // 'z' - 'a';
+        const int uppercaseZIndex = 'Z' - 'A';
+        const int lowercaseZIndex = 'z' - 'a';
 
         if (providerKind >= 'A' && providerKind <= 'Z')
         {

--- a/src/Cask/Helpers.cs
+++ b/src/Cask/Helpers.cs
@@ -59,7 +59,7 @@ internal static class Helpers
 
     public static CaskKeyKind CharToKind(char kindChar)
     {
-        Debug.Assert(kindChar == 'P' || kindChar == 'H',
+        Debug.Assert(kindChar == 'D' || kindChar == 'H' || kindChar == 'P',
                      "This is only meant to be called using the kind char of a known valid key.");
         return (CaskKeyKind)(kindChar - 'A');
     }
@@ -130,7 +130,7 @@ internal static class Helpers
         }
 
         kind = (CaskKeyKind)(value >> CaskKindReservedBits);
-        return true;
+        return kind is CaskKeyKind.DerivedKey or CaskKeyKind.HMAC or CaskKeyKind.PrimaryKey;
     }
 
     public static bool IsValidForBase64Url(string value)

--- a/src/Cask/Helpers.cs
+++ b/src/Cask/Helpers.cs
@@ -3,7 +3,6 @@
 
 global using static CommonAnnotatedSecurityKeys.Helpers;
 
-using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -70,36 +69,32 @@ internal static class Helpers
         return (byte)((int)kind << CaskKindReservedBits);
     }
 
-    public static byte ProviderKindToByte(string providerKind)
+    public static byte ProviderKindToByte(char providerKind)
     {
-        Debug.Assert(providerKind?.Length == 1, "Provider kind should be a single character.");
-
         int base64Index;
 
         const int uppercaseZIndex = 25; // 'Z' - 'A';
         const int lowercaseZIndex = 51; // 'z' - 'a';
 
-
-        char providerKindChar = providerKind[0];
-        if (providerKindChar >= 'A' && providerKindChar <= 'Z')
+        if (providerKind >= 'A' && providerKind <= 'Z')
         {
-            base64Index = providerKindChar - 'A';
+            base64Index = providerKind - 'A';
         }
-        else if (providerKindChar >= 'a' && providerKindChar <= 'z')
+        else if (providerKind >= 'a' && providerKind <= 'z')
         {
-            base64Index = providerKindChar - 'a' + uppercaseZIndex;
+            base64Index = providerKind - 'a' + uppercaseZIndex;
         }
-        else if (providerKindChar >= '0' && providerKindChar <= '9')
+        else if (providerKind >= '0' && providerKind <= '9')
         {
-            base64Index = providerKindChar - '0' + lowercaseZIndex;
+            base64Index = providerKind - '0' + lowercaseZIndex;
         }
-        else if (providerKindChar == '-')
+        else if (providerKind == '-')
         {
             base64Index = 62;
         }
         else
         {
-            Debug.Assert(providerKindChar == '_', "Provider kind should be a valid Base64Url char.");
+            Debug.Assert(providerKind == '_', "Provider kind should be a valid Base64Url char.");
             base64Index = 63;
         }
 

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -88,12 +88,12 @@ internal static partial class InternalConstants
     public const int MaxStackAlloc = 256;
 
     /// <summary>
-    /// The number of most significant bits reserved in the key kind byte.
+    /// The number of least significant bits reserved in the key kind byte.
     /// </summary>
     public const int CaskKindReservedBits = 4;
 
     /// <summary>
-    /// The number of most significant bits reserved in the key kind byte.
+    /// The number of least significant bits reserved in the sensitive key kind byte.
     /// </summary>
     public const int SensitiveDataSizeReservedBits = 6;
 

--- a/src/Tests/Cask.Benchmarks/BenchmarkTestData.cs
+++ b/src/Tests/Cask.Benchmarks/BenchmarkTestData.cs
@@ -10,7 +10,7 @@ internal static class BenchmarkTestData
     public const string TestDerivationInput = "Lorem ipsum dolor sit amet, consectetur adipiscing elit";
     public const string TestProviderData = "0123456789ABCDEF";
     public const string TestProviderSignature = "TEST";
-    public const string TestProviderKeyKind = "M";
+    public const char TestProviderKeyKind = 'M';
 
     public const int TestSecretEntropyInBytes = 32;
 

--- a/src/Tests/Cask.Tests/CSharpCaskTests.cs
+++ b/src/Tests/Cask.Tests/CSharpCaskTests.cs
@@ -11,7 +11,6 @@ using CSharpCask = CommonAnnotatedSecurityKeys.Cask;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class CSharpCaskTests : CaskTestsBase
 {
     public CSharpCaskTests() : base(new Implementation()) { }

--- a/src/Tests/Cask.Tests/CSharpCaskTests.cs
+++ b/src/Tests/Cask.Tests/CSharpCaskTests.cs
@@ -85,9 +85,10 @@ public class CSharpCaskTests : CaskTestsBase
             {
                 // See comment above for more information on this condition.
                 Assert.Fail(
-                    "Expected a failure condition as input key bytes did strictly conforming to input key string."
-                    + Environment.NewLine
-                    + $"key: {key}");
+                $"""
+                Expected a failure condition as input key bytes did strictly conforming to input key string.
+                key: {key}
+                """);
             }
 
             return result;

--- a/src/Tests/Cask.Tests/CSharpCaskTests.cs
+++ b/src/Tests/Cask.Tests/CSharpCaskTests.cs
@@ -47,6 +47,20 @@ public class CSharpCaskTests : CaskTestsBase
                 // will throw for this condition.
             }
 
+            if (key.Any((c) => !s_validBase64Url.Contains(c)))
+            {
+                // This condition will only occur if the input passed to
+                // `Base64Url.DecodeFromUtf8` included characters (such as 
+                // whitespace) that are not valid ('printable', i.e.,
+                // non-padding) usr-safe base64 characters. Keys that contain
+                // these characters are not valid Cask keys. Stripping them
+                // might actually result in the resulting bytes comprising
+                // a valid Cask key, so we won't test that API in this case.
+                // Since the input data has been demonstrated to be invalid,
+                // we will also ensure this test is a failure case below.
+                keyBytes = null;
+            }
+
             (string name, bool value)[] checks = [
                 ("Cask.IsCask(string)", result),
                 ("Cask.IsCask(ReadOnlySpan<char>)", CSharpCask.IsCask(key.AsSpan())),
@@ -65,6 +79,15 @@ public class CSharpCaskTests : CaskTestsBase
                     + $"key: {key}"
                     + Environment.NewLine
                     + string.Join(Environment.NewLine, checks.Select(c => $"  {c.name} -> {c.value}")));
+            }
+
+            if (keyBytes == null && result == true)
+            {
+                // See comment above for more information on this condition.
+                Assert.Fail(
+                    "Expected a failure condition as input key bytes did strictly conforming to input key string."
+                    + Environment.NewLine
+                    + $"key: {key}");
             }
 
             return result;

--- a/src/Tests/Cask.Tests/CSharpCaskTests.cs
+++ b/src/Tests/Cask.Tests/CSharpCaskTests.cs
@@ -19,7 +19,7 @@ public class CSharpCaskTests : CaskTestsBase
     private sealed class Implementation : ICask
     {
         public string GenerateKey(string providerSignature,
-                                  string providerKind = "A",
+                                  char providerKind,
                                   int expiryInFiveMinuteIncrements = 0,
                                   string? reserved = null)
         {

--- a/src/Tests/Cask.Tests/CaskKeyTests.cs
+++ b/src/Tests/Cask.Tests/CaskKeyTests.cs
@@ -24,7 +24,7 @@ public class CaskKeyTests
     public void CaskKey_KindIsPrimaryKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "_",
+                                       providerKeyKind: '_',
                                        expiryInFiveMinuteIncrements: 12 * 2, // 2 hours.
                                        providerData: "AaaA");
 
@@ -49,7 +49,7 @@ public class CaskKeyTests
         providerData ??= string.Empty;
 
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "O",
+                                       providerKeyKind: 'O',
                                        expiryInFiveMinuteIncrements: 0, // No expiry.
                                        providerData);
 
@@ -70,7 +70,7 @@ public class CaskKeyTests
     public void CaskKey_SensitiveDataSizeInBytes()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "_",
+                                       providerKeyKind: '_',
                                        expiryInFiveMinuteIncrements: (1 << 18) - 1, // 18-bit max value.
                                        providerData: "aBBa");
 
@@ -104,7 +104,7 @@ public class CaskKeyTests
     public void CaskKey_CreateOverloadsAreEquivalent()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "J",
+                                       providerKeyKind: 'J',
                                        expiryInFiveMinuteIncrements: 12 * 72, // 3 days.
                                        providerData: "MSFT");
 
@@ -127,7 +127,7 @@ public class CaskKeyTests
     public void CaskKey_DecodeBasic()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "9",
+                                       providerKeyKind: '9',
                                        expiryInFiveMinuteIncrements: 5, // 25 minutes.
                                        providerData: "010101010101");
 
@@ -144,7 +144,7 @@ public class CaskKeyTests
     public void CaskKey_TryEncodeInvalidKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "l",
+                                       providerKeyKind: 'l',
                                        expiryInFiveMinuteIncrements: 5, // 25 minutes.
                                        providerData: "010101010101");
 
@@ -165,7 +165,7 @@ public class CaskKeyTests
     public void CaskKey_TryEncodeBasic()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "J",
+                                       providerKeyKind: 'J',
                                        expiryInFiveMinuteIncrements: 0, // 3 days.
                                        providerData: null);
 
@@ -181,7 +181,7 @@ public class CaskKeyTests
     public void CaskKey_CreateOverloadsThrowOnInvalidKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
-                                       providerKeyKind: "R",
+                                       providerKeyKind: 'R',
                                        expiryInFiveMinuteIncrements: 12 * 24 * 365, // 1 year.
                                        providerData: "ROSS");
 

--- a/src/Tests/Cask.Tests/CaskKeyTests.cs
+++ b/src/Tests/Cask.Tests/CaskKeyTests.cs
@@ -232,7 +232,7 @@ public class CaskKeyTests
                            CaskKeyKind.HMAC;
 
             if (isValidEncodedByte)
-            { 
+            {
                 Assert.True(succeeded, $"Valid CaskKeyKind '{current}' failed 'CaskKey.TryEncode'");
                 continue;
             }

--- a/src/Tests/Cask.Tests/CaskKeyTests.cs
+++ b/src/Tests/Cask.Tests/CaskKeyTests.cs
@@ -3,14 +3,12 @@
 
 using System.Buffers.Text;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 using Xunit;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class CaskKeyTests
 {
     [Fact]
@@ -141,7 +139,34 @@ public class CaskKeyTests
     }
 
     [Fact]
-    public void CaskKey_TryEncodeInvalidKey()
+    public void CaskKey_Encode_InvalidKey()
+    {
+        CaskKey key = Cask.GenerateKey("TEST",
+                                       providerKeyKind: 'l',
+                                       expiryInFiveMinuteIncrements: 5, // 25 minutes.
+                                       providerData: "010101010101");
+
+        byte[] decoded = new byte[key.SizeInBytes];
+        byte[] tooSmall = new byte[key.SizeInBytes - 1];
+
+        Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
+        Array.Copy(decoded, tooSmall, tooSmall.Length);
+
+        // Break the key by creating an invalid length for decoding.
+        Assert.Throws<FormatException>(() => CaskKey.Encode(tooSmall));
+
+        decoded = new byte[key.SizeInBytes];
+        const int caskSignatureByteIndex = 33;
+        Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
+        Assert.Equal(0x40, decoded[caskSignatureByteIndex]);
+
+        // Break the key by invalidating the CASK signature.
+        decoded[caskSignatureByteIndex] = (byte)'X';
+        Assert.Throws<FormatException>(() => CaskKey.Encode(decoded));
+    }
+
+    [Fact]
+    public void CaskKey_TryEncode_InvalidKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: 'l',
@@ -151,18 +176,73 @@ public class CaskKeyTests
         Span<byte> decoded = stackalloc byte[key.SizeInBytes];
         Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
 
+        // Break the key by creating an invalid length for decoding.
+        bool succeeded = CaskKey.TryEncode(decoded[1..], out CaskKey newCaskKey);
+        Assert.False(succeeded);
+
         const int caskSignatureByteIndex = 33;
         Assert.Equal(0x40, decoded[caskSignatureByteIndex]);
 
-        // Break the key by invaliding the CASK signature.
+        // Break the key by invalidating the CASK signature.
         decoded[caskSignatureByteIndex] = (byte)'X';
 
-        bool succeeded = CaskKey.TryEncode(decoded, out CaskKey newCaskKey);
+        succeeded = CaskKey.TryEncode(decoded, out newCaskKey);
         Assert.False(succeeded);
     }
 
+
     [Fact]
-    public void CaskKey_TryEncodeBasic()
+    public void CaskKey_TryEncode_InvalidCaskKeyKind()
+    {
+        CaskKey key = Cask.GenerateKey("TEST",
+                                       providerKeyKind: '4',
+                                       expiryInFiveMinuteIncrements: 50, // 250 minutes.
+                                       providerData: "l33t");
+
+        Span<byte> decoded = stackalloc byte[key.SizeInBytes];
+        Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
+
+        const int caskKindByteIndex = 40;
+        const int caskKindReservedBits = 4;
+        const int caskKindMask = (1 << caskKindReservedBits) - 1;
+
+        for (byte i = byte.MinValue; i < byte.MaxValue; i++)
+        {
+            // This operation ensures that every possible byte
+            // value is populated and tested in encoding.
+            decoded[caskKindByteIndex] = i;
+
+            // Only the most significant 4 bits are valid to store key kind.
+            int iMasked = i & ~caskKindMask;
+
+            // Right-shifting by 4 bits gives us the literal key kind enum value;
+            var current = (CaskKeyKind)(iMasked >> caskKindReservedBits);
+
+            bool succeeded = CaskKey.TryEncode(decoded, out CaskKey newCaskKey);
+
+            // To test our API behavior, we first need to ensure that no bits
+            // were masked away from the input byte. This would indicate someone
+            // stepped on reserved padding, resulting in an invalid key. Next,
+            // we ensure that any bits stored in the proper place but which are
+            // not valid defined key kinds are also invalid.
+            bool isValidEncodedByte =
+                iMasked == i &&
+                current is CaskKeyKind.PrimaryKey or
+                           CaskKeyKind.DerivedKey or
+                           CaskKeyKind.HMAC;
+
+            if (isValidEncodedByte)
+            { 
+                Assert.True(succeeded, $"Valid CaskKeyKind '{current}' failed 'CaskKey.TryEncode'");
+                continue;
+            }
+
+            Assert.False(succeeded, $"Invalid CaskKeyKind value '{current}' passed 'CaskKey.TryEncode' check");
+        }
+    }
+
+    [Fact]
+    public void CaskKey_TryEncode_Basic()
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: 'J',
@@ -178,7 +258,7 @@ public class CaskKeyTests
     }
 
     [Fact]
-    public void CaskKey_CreateOverloadsThrowOnInvalidKey()
+    public void CaskKey_CreateOverloads_ThrowOnInvalidKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: 'R',
@@ -196,5 +276,20 @@ public class CaskKeyTests
         Assert.Throws<FormatException>(() => CaskKey.Create(invalidKeyText));
         Assert.Throws<FormatException>(() => CaskKey.Create(invalidKeyText.AsSpan()));
         Assert.Throws<FormatException>(() => CaskKey.CreateUtf8(invalidKeyUtf8Bytes));
+    }
+
+    [Fact]
+    public void CaskKey_Decode_DestinationTooSmall()
+    {
+        CaskKey key = Cask.GenerateKey("TEST",
+                                       providerKeyKind: 'W',
+                                       expiryInFiveMinuteIncrements: 12 * 24 * 365 * 2, // 2 years.
+                                       providerData: "WOLL");
+
+        byte[] destination = new byte[key.SizeInBytes];
+        key.Decode(destination);
+
+        destination = new byte[key.SizeInBytes - 1];
+        Assert.Throws<ArgumentException>(() => key.Decode(destination));
     }
 }

--- a/src/Tests/Cask.Tests/CaskSecretsTests.cs
+++ b/src/Tests/Cask.Tests/CaskSecretsTests.cs
@@ -3,8 +3,6 @@
 
 using System.Buffers.Text;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection.Metadata.Ecma335;
-using System.Text;
 
 using Xunit;
 

--- a/src/Tests/Cask.Tests/CaskSecretsTests.cs
+++ b/src/Tests/Cask.Tests/CaskSecretsTests.cs
@@ -12,7 +12,7 @@ using static CommonAnnotatedSecurityKeys.Limits;
 namespace CommonAnnotatedSecurityKeys.Tests;
 public abstract class CaskTestsBase
 {
-    private protected static new HashSet<char> s_validBase64Url =
+    private protected static HashSet<char> s_validBase64Url =
         [.. "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"];
 
     protected CaskTestsBase(ICask cask)
@@ -198,7 +198,7 @@ public abstract class CaskTestsBase
 
                 Span<char> invalidKeyChars = key.ToCharArray();
                 invalidKeyChars[ProviderKindCharIndex] = '=';
-                
+
                 IsCaskVerifyFailure(invalidKeyChars.ToString());
 
                 continue;

--- a/src/Tests/Cask.Tests/CppCaskTests.cs
+++ b/src/Tests/Cask.Tests/CppCaskTests.cs
@@ -32,8 +32,6 @@ namespace CommonAnnotatedSecurityKeys.Tests;
 //      To enable them, flip the return value of IsSupportedTestClass in
 //      TestFilter.cs.
 
-
-[ExcludeFromCodeCoverage]
 public class CppCaskTests : CaskTestsBase
 {
     public CppCaskTests() : base(new Implementation())

--- a/src/Tests/Cask.Tests/CppCaskTests.cs
+++ b/src/Tests/Cask.Tests/CppCaskTests.cs
@@ -43,7 +43,7 @@ public class CppCaskTests : CaskTestsBase
     private sealed class Implementation : ICask
     {
         public string GenerateKey(string providerSignature,
-                                  string providerKeyKind,
+                                  char providerKeyKind,
                                   int expiryInFiveMinuteIncrements = 0,
                                   string? providerData = null)
         {
@@ -87,7 +87,7 @@ public class CppCaskTests : CaskTestsBase
 
             [DllImport("libcask")]
             public static extern int Cask_GenerateKey([MarshalAs(LPUTF8Str)] string providerSignature,
-                                                      [MarshalAs(LPUTF8Str)] string? providerKeyKind,
+                                                      char providerKeyKind,
                                                       [MarshalAs(LPUTF8Str)] string? providerData,
                                                       byte[]? output,
                                                       int outputCapacity);

--- a/src/Tests/Cask.Tests/ICask.cs
+++ b/src/Tests/Cask.Tests/ICask.cs
@@ -24,7 +24,7 @@ public interface ICask
     bool IsCaskBytes(byte[] keyOrHash);
 
     string GenerateKey(string providerSignature,
-                       string providerKeyKind,
+                       char providerKeyKind,
                        int expiryInFiveMinuteIncrements,
                        string? providerData);
 

--- a/src/Tests/Cask.Tests/LimitTests.cs
+++ b/src/Tests/Cask.Tests/LimitTests.cs
@@ -8,7 +8,6 @@ using static CommonAnnotatedSecurityKeys.Limits;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class LimitTests
 {
     [Fact]

--- a/src/Tests/Cask.Tests/PolyfillTests.cs
+++ b/src/Tests/Cask.Tests/PolyfillTests.cs
@@ -30,7 +30,6 @@ using Xunit;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class PolyfillTests
 {
     [Fact]

--- a/src/Tests/Cask.Tests/TestFilter.cs
+++ b/src/Tests/Cask.Tests/TestFilter.cs
@@ -13,7 +13,6 @@ using Xunit.Sdk;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public sealed class TestFilter : XunitTestFramework
 {
     private static readonly bool s_builtWithCppSupport = IsBuiltWithCppSupport();

--- a/src/libcask/cask.cpp
+++ b/src/libcask/cask.cpp
@@ -21,7 +21,7 @@ CASK_API bool Cask_IsCaskBytes(const uint8_t* keyOrHashBytes,
 }
 
 CASK_API int32_t Cask_GenerateKey(const char* providerSignature,
-                                  const char* providerKeyKind,
+                                  const char providerKeyKind,
                                   const char* providerData,
                                   char* output,
                                   int32_t outputSizeInBytes)

--- a/src/libcask/cask.h
+++ b/src/libcask/cask.h
@@ -29,7 +29,7 @@ CASK_API bool Cask_IsCaskBytes(const uint8_t* keyOrHashBytes,
                                int32_t length);
 
 CASK_API int32_t Cask_GenerateKey(const char* providerSignature,
-                                  const char* providerKeyKind,
+                                  const char providerKeyKind,
                                   const char* providerData,
                                   char* buffer,
                                   int32_t bufferSize);


### PR DESCRIPTION
Code change to resolve #33.

Currently, provider key kind is a string, which we check to ensure is non-null, has length of 1, is url safe base64, etc.

The change is to accept a char value only for the provider key kind (which ends up being encoded into 6 bits of the key). This is a more appropriate data type and also simplifies validation and some other logic.