### PR TITLE
Fill more coverage holes. Remove test file code coverage exclusion attributes

### DIFF
--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -220,9 +220,9 @@ public static class Cask
         Debug.Assert(bytesWritten == providerData.Length / 4 * 3);
     }
 
-    public static void ComputeExpiryChars(int expiryInFiveMinuteIncrements, Span<char> destination)
+    private static void ComputeExpiryChars(int expiryInFiveMinuteIncrements, Span<char> destination)
     {
-        ThrowIfDestinationTooSmall(destination, 3);
+        Debug.Assert(destination.Length == 3);
         ValidateExpiry(expiryInFiveMinuteIncrements);
 
         Span<char> expiryChars = stackalloc char[4];

--- a/src/Cask/CaskKey.cs
+++ b/src/Cask/CaskKey.cs
@@ -107,16 +107,13 @@ public readonly partial record struct CaskKey : IIsInitialized
 
     public static bool TryEncode(ReadOnlySpan<byte> bytes, out CaskKey key)
     {
-        key = default;
-
-
         if (!Cask.IsCaskBytes(bytes))
         {
+            key = default;
             return false;
         }
 
         key = new CaskKey(Base64Url.EncodeToString(bytes));
-
         return true;
     }
 

--- a/src/Cask/CaskKey.cs
+++ b/src/Cask/CaskKey.cs
@@ -107,13 +107,16 @@ public readonly partial record struct CaskKey : IIsInitialized
 
     public static bool TryEncode(ReadOnlySpan<byte> bytes, out CaskKey key)
     {
+        key = default;
+
+
         if (!Cask.IsCaskBytes(bytes))
         {
-            key = default;
             return false;
         }
 
         key = new CaskKey(Base64Url.EncodeToString(bytes));
+
         return true;
     }
 

--- a/src/Cask/Helpers.cs
+++ b/src/Cask/Helpers.cs
@@ -59,7 +59,7 @@ internal static class Helpers
 
     public static CaskKeyKind CharToKind(char kindChar)
     {
-        Debug.Assert(kindChar == 'P' || kindChar == 'H',
+        Debug.Assert(kindChar == 'D' || kindChar == 'H' || kindChar == 'P',
                      "This is only meant to be called using the kind char of a known valid key.");
         return (CaskKeyKind)(kindChar - 'A');
     }
@@ -130,7 +130,7 @@ internal static class Helpers
         }
 
         kind = (CaskKeyKind)(value >> CaskKindReservedBits);
-        return true;
+        return kind is CaskKeyKind.DerivedKey or CaskKeyKind.HMAC or CaskKeyKind.PrimaryKey;
     }
 
     public static bool IsValidForBase64Url(string value)

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -88,12 +88,12 @@ internal static partial class InternalConstants
     public const int MaxStackAlloc = 256;
 
     /// <summary>
-    /// The number of most significant bits reserved in the key kind byte.
+    /// The number of least significant bits reserved in the key kind byte.
     /// </summary>
     public const int CaskKindReservedBits = 4;
 
     /// <summary>
-    /// The number of most significant bits reserved in the key kind byte.
+    /// The number of least significant bits reserved in the sensitive key kind byte.
     /// </summary>
     public const int SensitiveDataSizeReservedBits = 6;
 

--- a/src/Tests/Cask.Tests/CSharpCaskTests.cs
+++ b/src/Tests/Cask.Tests/CSharpCaskTests.cs
@@ -11,7 +11,6 @@ using CSharpCask = CommonAnnotatedSecurityKeys.Cask;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class CSharpCaskTests : CaskTestsBase
 {
     public CSharpCaskTests() : base(new Implementation()) { }

--- a/src/Tests/Cask.Tests/CaskKeyTests.cs
+++ b/src/Tests/Cask.Tests/CaskKeyTests.cs
@@ -3,14 +3,12 @@
 
 using System.Buffers.Text;
 using System.Diagnostics.CodeAnalysis;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 using Xunit;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class CaskKeyTests
 {
     [Fact]
@@ -141,7 +139,34 @@ public class CaskKeyTests
     }
 
     [Fact]
-    public void CaskKey_TryEncodeInvalidKey()
+    public void CaskKey_Encode_InvalidKey()
+    {
+        CaskKey key = Cask.GenerateKey("TEST",
+                                       providerKeyKind: 'l',
+                                       expiryInFiveMinuteIncrements: 5, // 25 minutes.
+                                       providerData: "010101010101");
+
+        byte[] decoded = new byte[key.SizeInBytes];
+        byte[] tooSmall = new byte[key.SizeInBytes - 1];
+
+        Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
+        Array.Copy(decoded, tooSmall, tooSmall.Length);
+
+        // Break the key by creating an invalid length for decoding.
+        Assert.Throws<FormatException>(() => CaskKey.Encode(tooSmall));
+
+        decoded = new byte[key.SizeInBytes];
+        const int caskSignatureByteIndex = 33;
+        Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
+        Assert.Equal(0x40, decoded[caskSignatureByteIndex]);
+
+        // Break the key by invalidating the CASK signature.
+        decoded[caskSignatureByteIndex] = (byte)'X';
+        Assert.Throws<FormatException>(() => CaskKey.Encode(decoded));
+    }
+
+    [Fact]
+    public void CaskKey_TryEncode_InvalidKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: 'l',
@@ -151,18 +176,73 @@ public class CaskKeyTests
         Span<byte> decoded = stackalloc byte[key.SizeInBytes];
         Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
 
+        // Break the key by creating an invalid length for decoding.
+        bool succeeded = CaskKey.TryEncode(decoded[1..], out CaskKey newCaskKey);
+        Assert.False(succeeded);
+
         const int caskSignatureByteIndex = 33;
         Assert.Equal(0x40, decoded[caskSignatureByteIndex]);
 
-        // Break the key by invaliding the CASK signature.
+        // Break the key by invalidating the CASK signature.
         decoded[caskSignatureByteIndex] = (byte)'X';
 
-        bool succeeded = CaskKey.TryEncode(decoded, out CaskKey newCaskKey);
+        succeeded = CaskKey.TryEncode(decoded, out newCaskKey);
         Assert.False(succeeded);
     }
 
+
     [Fact]
-    public void CaskKey_TryEncodeBasic()
+    public void CaskKey_TryEncode_InvalidCaskKeyKind()
+    {
+        CaskKey key = Cask.GenerateKey("TEST",
+                                       providerKeyKind: '4',
+                                       expiryInFiveMinuteIncrements: 50, // 250 minutes.
+                                       providerData: "l33t");
+
+        Span<byte> decoded = stackalloc byte[key.SizeInBytes];
+        Base64Url.DecodeFromChars(key.ToString().AsSpan(), decoded);
+
+        const int caskKindByteIndex = 40;
+        const int caskKindReservedBits = 4;
+        const int caskKindMask = (1 << caskKindReservedBits) - 1;
+
+        for (byte i = byte.MinValue; i < byte.MaxValue; i++)
+        {
+            // This operation ensures that every possible byte
+            // value is populated and tested in encoding.
+            decoded[caskKindByteIndex] = i;
+
+            // Only the most significant 4 bits are valid to store key kind.
+            int iMasked = i & ~caskKindMask;
+
+            // Right-shifting by 4 bits gives us the literal key kind enum value;
+            var current = (CaskKeyKind)(iMasked >> caskKindReservedBits);
+
+            bool succeeded = CaskKey.TryEncode(decoded, out CaskKey newCaskKey);
+
+            // To test our API behavior, we first need to ensure that no bits
+            // were masked away from the input byte. This would indicate someone
+            // stepped on reserved padding, resulting in an invalid key. Next,
+            // we ensure that any bits stored in the proper place but which are
+            // not valid defined key kinds are also invalid.
+            bool isValidEncodedByte =
+                iMasked == i &&
+                current is CaskKeyKind.PrimaryKey or
+                           CaskKeyKind.DerivedKey or
+                           CaskKeyKind.HMAC;
+
+            if (isValidEncodedByte)
+            { 
+                Assert.True(succeeded, $"Valid CaskKeyKind '{current}' failed 'CaskKey.TryEncode'");
+                continue;
+            }
+
+            Assert.False(succeeded, $"Invalid CaskKeyKind value '{current}' passed 'CaskKey.TryEncode' check");
+        }
+    }
+
+    [Fact]
+    public void CaskKey_TryEncode_Basic()
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: 'J',
@@ -178,7 +258,7 @@ public class CaskKeyTests
     }
 
     [Fact]
-    public void CaskKey_CreateOverloadsThrowOnInvalidKey()
+    public void CaskKey_CreateOverloads_ThrowOnInvalidKey()
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: 'R',
@@ -196,5 +276,20 @@ public class CaskKeyTests
         Assert.Throws<FormatException>(() => CaskKey.Create(invalidKeyText));
         Assert.Throws<FormatException>(() => CaskKey.Create(invalidKeyText.AsSpan()));
         Assert.Throws<FormatException>(() => CaskKey.CreateUtf8(invalidKeyUtf8Bytes));
+    }
+
+    [Fact]
+    public void CaskKey_Decode_DestinationTooSmall()
+    {
+        CaskKey key = Cask.GenerateKey("TEST",
+                                       providerKeyKind: 'W',
+                                       expiryInFiveMinuteIncrements: 12 * 24 * 365 * 2, // 2 years.
+                                       providerData: "WOLL");
+
+        byte[] destination = new byte[key.SizeInBytes];
+        key.Decode(destination);
+
+        destination = new byte[key.SizeInBytes - 1];
+        Assert.Throws<ArgumentException>(() => key.Decode(destination));
     }
 }

--- a/src/Tests/Cask.Tests/CppCaskTests.cs
+++ b/src/Tests/Cask.Tests/CppCaskTests.cs
@@ -32,8 +32,6 @@ namespace CommonAnnotatedSecurityKeys.Tests;
 //      To enable them, flip the return value of IsSupportedTestClass in
 //      TestFilter.cs.
 
-
-[ExcludeFromCodeCoverage]
 public class CppCaskTests : CaskTestsBase
 {
     public CppCaskTests() : base(new Implementation())

--- a/src/Tests/Cask.Tests/LimitTests.cs
+++ b/src/Tests/Cask.Tests/LimitTests.cs
@@ -8,7 +8,6 @@ using static CommonAnnotatedSecurityKeys.Limits;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class LimitTests
 {
     [Fact]

--- a/src/Tests/Cask.Tests/PolyfillTests.cs
+++ b/src/Tests/Cask.Tests/PolyfillTests.cs
@@ -30,7 +30,6 @@ using Xunit;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public class PolyfillTests
 {
     [Fact]

--- a/src/Tests/Cask.Tests/TestFilter.cs
+++ b/src/Tests/Cask.Tests/TestFilter.cs
@@ -13,7 +13,6 @@ using Xunit.Sdk;
 
 namespace CommonAnnotatedSecurityKeys.Tests;
 
-[ExcludeFromCodeCoverage]
 public sealed class TestFilter : XunitTestFramework
 {
     private static readonly bool s_builtWithCppSupport = IsBuiltWithCppSupport();


### PR DESCRIPTION
This change replaces actual thought and discernment about what tests to author by simply observing what's uncovered and closing those gaps. That doesn't mean we shouldn't go back and revisit the tests for clarity and consistent, i.e., to ensure that some code paths aren't being opportunistically covered rather than by explicit, intentional tests.

But I think it's important and useful to first ensure that everything is covered, so that we have that preliminary confidence. And, in fact, and as usual, this exercise of closing all the little open places was productive a bug fix.

Changes include:

- I've dropped the visibility of `Cask.ComputeExpiryChars` to private as this data is proposed to become optional (and removed from the official API). This prompted me to drop a `ThrowIf` protection to a debug assert, as we now have complete control over all callers.
- `Helpers.TryByteToKind` now only validates the three legal cask key kinds, rather than permitting any value that didn't clobber the reserved padding in its relevant byte.
- Updated some comments.
- Mostly just added coverage. We now have basically 100% code coverage in the API. There are some partial misses related to missed conditions in a Debug.Assert (not relevant to production scenario). The only other remaining gap is in a helper that's slated to get zapped when we eliminate the explicit encoding of the sensitive component size.
