### PR TITLE
[WIP] Update some occurrences of sensitiveDataSize to secretSize to reflect enum name change.

### DIFF
--- a/src/Cask/CaskKey.cs
+++ b/src/Cask/CaskKey.cs
@@ -32,7 +32,7 @@ public readonly partial record struct CaskKey : IIsInitialized
         get
         {
             ThrowIfNotInitialized();
-            return Cask.ExtractSensitiveDataSizeFromKeyChars(_key.AsSpan(), out Range _);
+            return Cask.ExtractSecretSizeFromKeyChars(_key.AsSpan(), out Range _);
         }
     }
 

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -71,5 +71,5 @@ internal static partial class InternalConstants
     /// The integer offset of the sensitive data size relative to the
     /// Cask signature in a base64-encoded secret.
     /// </summary>
-    public static int SensitiveDataSizeOffsetFromCaskSignatureChar => 5;
+    public static int SecretSizeOffsetFromCaskSignatureChar => 5;
 }

--- a/src/Tests/Cask.Tests/CaskKeyTests.cs
+++ b/src/Tests/Cask.Tests/CaskKeyTests.cs
@@ -67,7 +67,7 @@ public class CaskKeyTests
     [InlineData(SecretSize.Bits256)]
     [InlineData(SecretSize.Bits384)]
     [InlineData(SecretSize.Bits512)]
-    public void CaskKey_SensitiveDataSize(SecretSize secretSize)
+    public void CaskKey_SecretSize(SecretSize secretSize)
     {
         CaskKey key = Cask.GenerateKey("TEST",
                                        providerKeyKind: '_',
@@ -185,12 +185,12 @@ public class CaskKeyTests
 
         Span<char> keyChars = key.ToString().ToCharArray().AsSpan();
 
-        int sensitiveDataSizeCharOffset = 53;
-        var sensitiveDataSize = (SecretSize)(keyChars[sensitiveDataSizeCharOffset] - 'A');
+        int secretSizeCharOffset = 53;
+        var secretSize = (SecretSize)(keyChars[secretSizeCharOffset] - 'A');
 
-        Assert.Equal(SecretSize.Bits256, sensitiveDataSize);
+        Assert.Equal(SecretSize.Bits256, secretSize);
 
-        keyChars[sensitiveDataSizeCharOffset] = (char)('A' + ((int)SecretSize.Bits512 + 1));
+        keyChars[secretSizeCharOffset] = (char)('A' + ((int)SecretSize.Bits512 + 1));
         Base64Url.TryDecodeFromChars(keyChars, decoded, out int _);
 
         Assert.Throws<FormatException>(() => CaskKey.Encode(decoded));

--- a/src/Tests/Cask.Tests/CaskSecretsTests.cs
+++ b/src/Tests/Cask.Tests/CaskSecretsTests.cs
@@ -122,8 +122,8 @@ public abstract class CaskTestsBase
             Assert.Equal(0, keyBytes[secretSizeInBytes + i]);
         }
 
-        int sensitiveDataSizeInChar = (paddedSecretSizeInBytes / 3) * 4;
-        string encodedSensitiveData = encodedKey[..sensitiveDataSizeInChar];
+        int paddedSecretSizeInChars = (paddedSecretSizeInBytes / 3) * 4;
+        string encodedSensitiveData = encodedKey[..paddedSecretSizeInChars];
 
         // If we have non-zero padding bytes, there will be an encoded character
         // with either two or four bits of trailing zeros, which bring the data
@@ -165,7 +165,7 @@ public abstract class CaskTestsBase
         Assert.True(keyBytes[caskSignatureRangeInBytes].SequenceEqual(caskSignatureBytes));
         Assert.True(keyBytes[caskSignatureRangeInBytes].SequenceEqual([(byte)0x40, (byte)0x92, (byte)0x50]));
 
-        Range caskSignatureRangeInChars = sensitiveDataSizeInChar..(sensitiveDataSizeInChar + 4);
+        Range caskSignatureRangeInChars = paddedSecretSizeInChars..(paddedSecretSizeInChars + 4);
         Assert.Equal(caskSignature, encodedKey[caskSignatureRangeInChars]);
 
         // The timestamp, sensitive data size, optional data size, and provider key kind
@@ -273,9 +273,9 @@ public abstract class CaskTestsBase
 
         var utcTimestamp = new DateTimeOffset(year + 2025, month + 1, day + 1, hour, minute, second: 0, TimeSpan.Zero);
 
-        char encodedSensitiveDataSizeChar = encodedTimestampSizesAndKindChars[5];
-        var encodedSensitiveDataSize = (SecretSize)base64UrlPrintableCharIndices[encodedSensitiveDataSizeChar];
-        Assert.Equal(secretSize, encodedSensitiveDataSize);
+        char encodedSecretSizeChar = encodedTimestampSizesAndKindChars[5];
+        var encodedSecretSize = (SecretSize)base64UrlPrintableCharIndices[encodedSecretSizeChar];
+        Assert.Equal(secretSize, encodedSecretSize);
 
         char encodedOptionalDataSizeChar = encodedTimestampSizesAndKindChars[6];
         int optionalDataSizeInBytes = base64UrlPrintableCharIndices[encodedOptionalDataSizeChar] * 3;


### PR DESCRIPTION
I foolishly renamed the `SensitiveDataSize` enum to `SecretSize` in the last PR, without appreciating the scale of rename required to put the code in a consistent condition. We need terminology here that makes the sensitive component data clear.

`SecretSize` == a count of 16-byte segments that are used to store the literal secret encoded in a CASK secret (and now I'm getting concerned that calling all of these cask 'secrets' is itself confusing).
`secretSizeInBytes` = the computed size in bytes for the literal secret.
`paddedSecretSizeInBytes` = the final, padded (if necessary) byte range that brings the sensitive data component to a 3-byte boundary.