### PR TITLE
Reorder sensitive data, optional data size, et al. as described in #48

### DIFF
--- a/docs/CaskSecret.md
+++ b/docs/CaskSecret.md
@@ -3,9 +3,9 @@
 ```
 <key> ::= <sensitive-data>      ; A sequence of security-sensitive bytes.
           <cask-signature>      ; A fixed signature (`QJJQ`) that enables high-performance textual identification.
-          <timestamp>           ; The year, month, day, hour, and minute of secret allocation.
           <sensitive-data-size> ; A count of 16-byte segments encoded as sensitive data ('B' = 1 x 16 bytes = 128 bits, etc).
           <optional-data-size>  ; A count of 3-byte optional data segments, 'A' = 0 = 0 bytes, 'B' = 1 = 3 bytes, etc.
+          <timestamp>           ; The year, month, day, hour, and minute of secret allocation.
           <provider-kind>       ; A provider-defined key kind.
           [<optional-fields>]   ; Optional fields comprising provider-defined data.
           <provider-signature>  ; A fixed signature identifying the secret provider.
@@ -41,14 +41,14 @@
                             | 'g' | 'k' | 'o' | 's' | 'w' | '0' | '4' | '8' ; Base64 printable characters with two trailing zero bits.
 <base64-four-zeros-suffix> ::= 'A' | 'Q' | 'g' | 'w'                        ; Base64 printable characters with four trailing zero bits.
 <cask-signature> ::= 'QJJQ'                                                 ; Fixed signature identifying the CASK key.
+<sensitive-data-size> ::= 'A'                                               ; 'A' indicates a 128-bit sensitive data component, 'B' 256-bit, etc.
+<optional-data-size> ::= 'A'                                                ; 'A' = zero 3-byte optional bytes, 'B' = one optional 3-byte segment, etc.
 <timestamp> ::= <year> <month> <day> <hour> <minute>                        ; Time-of-allocation timestamp components.
 <year> ::= <base64url>                                                      ; Allocation year, 'A' (2025) to '_' (2088).
 <month> ::= 'A'..'L'                                                        ; Allocation month, 'A' (January) to 'L' (December).
 <day> ::= 'A'..'Z' | 'a'..'e'                                               ; 'A' = day 1, 'B' = day 2, ... 'e' = day 31
 <hour> ::= 'A'..'X'                                                         ; Represents hours 0-23. 'A' = hour 0 (midnight), ... 'X' = hour 23.
 <minute> ::= 'A'..'7'                                                       ; Represents minutes 0-59.
-<sensitive-data-size> ::= 'A'                                               ; 'A' indicates a 128-bit sensitive data component, 'B' 256-bit, etc.
-<optional-data-size> ::= 'A'                                                ; 'A' = zero 3-byte optional bytes, 'B' = one optional 3-byte segment, etc.
 <provider-kind> ::= <base64url>                                             ; Provider-defined key kind.
 <provider-signature> ::= 4 * <base64url>                                    ; Provider identifier (24 bits).
 <optional-fields> ::= { <optional-field> }                                  ; Zero or more 4-character (24-bit) sequences of optional data.
@@ -68,8 +68,8 @@
 |decodedKey[..31]|0...255|0x0...0xFF|00000000b...11111111b|256 bits of sensitive data produced by a cryptographically secure RNG, an HMAC, etc.|
 |decodedKey[32]|0|0x00|00000000b| 8 bits of reserved padding.
 |decodedKey[33..36]| 37, 4, 9  |0x40, 0x92, 0x50| 00100000b, 10010010b, 01010000b | Decoded 'QJJQ' signature.
-|decodedKey[36..39]||||Timestamp data encoded in 4 six-bit segments for YMDH.
-|decodedKey[39..42]||||Timestamp minutes, sensitive data size, optional-data-size, and provider kind data encoded in 4 six-bit segments.
+|decodedKey[36..39]||||Sensitive data size, optional-data-size, timestamp year and month encoded in 4 six-bit segments.
+|decodedKey[39..42]||||Timestamp day, hour, minutes and provider kind data encoded in 4 six-bit segments.
 |decodedKey[42..45]|0...255|0x0...0xFF|00000000b...11111111b| Provider signature, e.g. , '0x4c', '0x44', '0x93' (base64-encoded as 'TEST')
 |decodedKey[45..60]||||16 byte non-sensitive, unique correlating id.
 
@@ -80,13 +80,13 @@
 |encodedKey[42] | <base64-two-zeros-suffix> | 4 bits of randomized data followed by 2 zero bits. See the <base64-two-zeros-suffix> definition for legal values.
 |encodedKey[43] | 'A' | The 6-bit encoded sensitive component size.
 |encodedKey[44..48]|'QJJQ'| Fixed CASK signature.
-|encodedKey[48]|'A'...'_'|Represents the year of allocation time, 'A' (2025) to '_' (2088)|
-|encodedKey[49|'A'...'L'|Represents the month of allocation time, 'A' (January) to 'L' (December)|
-|encodedKey[50]|'A'...'Z'\|'a'..'e'|Represents the day of allocation time, 'A' (0) to 'e' (31)|
-|encodedKey[51]|'A'...'X'|Represents the hour of allocation time, 'A' (hour 0 or midnight) to 'X' (hour 23).
-|encodedKey[52]|'A'...'7'| Represents the minute of allocation time.
-|encodedKey[53]|'A'...'D'| Sensitive component key size, 'A' (128-bit), 'B' (256-bit), 'C' (384-bit) or 'D' (512-bit).
-|encodedKey[54]|'A'...'?'| Count of optional 3-byte data segments, 'A' == 0 bytes, 'B' == 3 bytes, capped at ?? (maximum permissible would be 189 bytes, 63 * 3)
+|encodedKey[48]|'A'...'D'| Sensitive component key size, 'A' (128-bit), 'B' (256-bit), 'C' (384-bit) or 'D' (512-bit).
+|encodedKey[49]|'A'...'?'| Count of optional 3-byte data segments, 'A' == 0 bytes, 'B' == 3 bytes, capped at ?? (maximum permissible would be 189 bytes, 63 * 3)
+|encodedKey[50]|'A'...'_'|Represents the year of allocation time, 'A' (2025) to '_' (2088)|
+|encodedKey[51|'A'...'L'|Represents the month of allocation time, 'A' (January) to 'L' (December)|
+|encodedKey[52]|'A'...'Z'\|'a'..'e'|Represents the day of allocation time, 'A' (0) to 'e' (31)|
+|encodedKey[53]|'A'...'X'|Represents the hour of allocation time, 'A' (hour 0 or midnight) to 'X' (hour 23).
+|encodedKey[54]|'A'...'7'| Represents the minute of allocation time.
 |encodedKey[55]|'A'...'_'| Provider-defined key kind.
 |encodedKey[55..75]|'A'...'_'| Correlating id.
 ```

--- a/docs/CaskSecret.md
+++ b/docs/CaskSecret.md
@@ -41,8 +41,9 @@
                             | 'g' | 'k' | 'o' | 's' | 'w' | '0' | '4' | '8' ; Base64 printable characters with two trailing zero bits.
 <base64-four-zeros-suffix> ::= 'A' | 'Q' | 'g' | 'w'                        ; Base64 printable characters with four trailing zero bits.
 <cask-signature> ::= 'QJJQ'                                                 ; Fixed signature identifying the CASK key.
-<sensitive-data-size> ::= 'A'                                               ; 'A' indicates a 128-bit sensitive data component, 'B' 256-bit, etc.
-<optional-data-size> ::= 'A'                                                ; 'A' = zero 3-byte optional bytes, 'B' = one optional 3-byte segment, etc.
+<sensitive-data-size> ::= 'B'..'E'                                          ; 'B' = 128-bit secret size, 'C' = 256-bit, 'D' = 384-bit, 'E' = 512-bit.
+<optional-data-size> ::= 'A'..'E'                                           ; 'A' = zero 3-byte optional data segments, 'B' = one optional 3-byte
+                                                                            ; segment, up to a maximum of 'E' = 4 optional 3-byte data segments.
 <timestamp> ::= <year> <month> <day> <hour> <minute>                        ; Time-of-allocation timestamp components.
 <year> ::= <base64url>                                                      ; Allocation year, 'A' (2025) to '_' (2088).
 <month> ::= 'A'..'L'                                                        ; Allocation month, 'A' (January) to 'L' (December).

--- a/docs/GenerateKeyPseudoCode.md
+++ b/docs/GenerateKeyPseudoCode.md
@@ -36,16 +36,16 @@
 1. Clear the padding bytes, if any, that follow the secret and which bring alignment to a 3-byte boundary.
 1. Write CASK signature [0x40, 0x92, 0x50] ("QJJQ", base64-decoded) to the next 3 bytes.
 1. Retrieve the current date and time in UTC and store the result in T.
-1. Encode T in 4 characters, YMDH:
-    - Y = base64url-encoding of T.Year - 2025.
-    - M = base64url-encoding of T.Month as a zero-based value, 0 - 11.
-    - D = base64url-encoding of T.Day as a zero-based value, i.e., 0 - 30.
-    - H = base64url-encoding of T.Hour as zero-based value, i.e., 0 - 23.
-1. Base64url-decode YMDH and store the result in the next 3 bytes.
-1. Encode the timestamp minutes, data sizes and provider key kind in 4 characters, MSOK:
-    - M = base64url-encoding of T.Minutes as a zero-based value, i.e., 0 - 59.
+1. Encode the secret and optional data sizes, year, and month of T in 4 characters, SOYM:
     - S = base64url-encoding of secret data size, one of 1 (128 bits), 2 (256), 3 (384), or 4 (512).
     - O = base64url-encoding of optional data size, a count of 3-byte segments, one of 0 - 4.
+    - Y = base64url-encoding of T.Year - 2025.
+    - M = base64url-encoding of T.Month as a zero-based value, 0 - 11.
+1. Base64url-decode SOYM and store the result in the next 3 bytes.
+1. Encode the timestamp day, hour and minutes, and provider key kind in 4 characters, DHMK:
+    - D = base64url-encoding of T.Day as a zero-based value, i.e., 0 - 30.
+    - H = base64url-encoding of T.Hour as zero-based value, i.e., 0 - 23.
+    - M = base64url-encoding of T.Minutes as a zero-based value, i.e., 0 - 59.
     - K = provider key kind, i.e., the exact base64url printable char specified by the caller.
 1. Base64url-decode MSOK and store the result in the next 3 bytes.
 1. Base64url-decode provider signature and store the result in the next 3 bytes.

--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -100,12 +100,11 @@ public static class Cask
         }
 
         ReadOnlySpan<byte> source = keyBytes[caskSignatureByteRange.End.Value..];
-
-        ReadOnlySpan<byte> secretOptionalSizesYearMonthBytes = source[..DataLengthsYearMonthSizeInBytes];
-        source = source[DataLengthsYearMonthSizeInBytes..];
+        ReadOnlySpan<byte> dataLengthsTimeStampProviderKeyKindBytes = source[..DataLengthsTimeStampProviderKeyKindSizeInBytes];
+        source = source[DataLengthsTimeStampProviderKeyKindSizeInBytes..];
 
         Span<char> dataLengthsTimeStampProviderKeyKindChars = stackalloc char[DataLengthsTimeStampProviderKeyKindSizeInChars];
-        int bytesWritten = Base64Url.EncodeToChars(secretOptionalSizesYearMonthBytes, secretOptionalSizesYearMonthChars);
+        int bytesWritten = Base64Url.EncodeToChars(dataLengthsTimeStampProviderKeyKindBytes, dataLengthsTimeStampProviderKeyKindChars);
         Debug.Assert(bytesWritten == DataLengthsTimeStampProviderKeyKindSizeInChars);
 
         // 'A' == index 0 of all printable base64-encoded characters.
@@ -137,8 +136,6 @@ public static class Cask
         {
             return false;
         }
-
-        ReadOnlySpan<byte> dayHoursMinutesProviderKindBytes = source[..DayHourMinutesKeyKindSizeInBytes];
 
         char day = dataLengthsTimeStampProviderKeyKindChars[4];
         // An encoded day (a zero-indexed value) that exceeds 30 ('e') is not valid.
@@ -220,22 +217,15 @@ public static class Cask
             Base64UrlChars[providerDataLengthInBytes/3],
             Base64UrlChars[now.Year - 2025], // Years since 2025.
             Base64UrlChars[now.Month - 1],   // Zero-indexed month.
-        ];
-
-        int bytesWritten = Base64Url.DecodeFromChars(chars, destination[..DataLengthsYearMonthSizeInBytes]);
-        Debug.Assert(bytesWritten == DataLengthsYearMonthSizeInBytes);
-        destination = destination[DataLengthsYearMonthSizeInBytes..];
-
-        chars = [
             Base64UrlChars[now.Day - 1],     // Zero-indexed day.
             Base64UrlChars[now.Hour],        // Zero-indexed hour.
             Base64UrlChars[now.Minute],      // Zero-index minute.
             providerKeyKind,
         ];
 
-        bytesWritten = Base64Url.DecodeFromChars(chars, destination[..DayHourMinutesKeyKindSizeInBytes]);
-        Debug.Assert(bytesWritten == DayHourMinutesKeyKindSizeInBytes);
-        destination = destination[DayHourMinutesKeyKindSizeInBytes..];
+        int bytesWritten = Base64Url.DecodeFromChars(chars, destination[..DataLengthsTimeStampProviderKeyKindSizeInBytes]);
+        Debug.Assert(bytesWritten == DataLengthsTimeStampProviderKeyKindSizeInBytes);
+        destination = destination[DataLengthsTimeStampProviderKeyKindSizeInBytes..];
 
         bytesWritten = Base64Url.DecodeFromChars(providerData.AsSpan(), destination[..providerDataLengthInBytes]);
         Debug.Assert(bytesWritten == providerDataLengthInBytes);

--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -104,7 +104,7 @@ public static class Cask
         ReadOnlySpan<byte> secretOptionalSizesYearMonthBytes = destination[..DataLengthsYearMonthSizeInBytes];
         destination = destination[DataLengthsYearMonthSizeInBytes..];
 
-        Span<char> secretOptionalSizesYearMonthChars = stackalloc char[4];
+        Span<char> secretOptionalSizesYearMonthChars = stackalloc char[DataLengthsYearMonthSizeInChars];
         int bytesWritten = Base64Url.EncodeToChars(secretOptionalSizesYearMonthBytes, secretOptionalSizesYearMonthChars);
         Debug.Assert(bytesWritten == DataLengthsYearMonthSizeInChars);
 
@@ -140,7 +140,7 @@ public static class Cask
 
         ReadOnlySpan<byte> dayHoursMinutesProviderKindBytes = destination[..DayHourMinutesKeyKindSizeInBytes];
 
-        Span<char> dayHourMinutesAndProviderKindChars = stackalloc char[4];
+        Span<char> dayHourMinutesAndProviderKindChars = stackalloc char[DayHourMinutesKeyKindSizeInChars];
         bytesWritten = Base64Url.EncodeToChars(dayHoursMinutesProviderKindBytes, dayHourMinutesAndProviderKindChars);
         Debug.Assert(bytesWritten == DayHourMinutesKeyKindSizeInChars);
 

--- a/src/Cask/CaskKey.cs
+++ b/src/Cask/CaskKey.cs
@@ -172,7 +172,10 @@ public readonly partial record struct CaskKey : IIsInitialized
     }
 
     // language=regex
-    private const string RegexPattern = """(^|[^A-Za-z0-9+\/\-_])([A-Za-z0-9\-_]{4}([A-Za-z0-9\-_]{20}){1,3}|[A-Za-z0-9\-_]{88})?QJJQ[A-Za-z0-9\-_][A-L][A-Za-e][A-X][A-Za-z0-7][B-E][A-E][A-Za-z0-9\-_]([A-Za-z0-9\-_]{4}){0,4}[A-Za-z0-9\-_]{24}([^A-Za-z0-9+\/\-_]|$)""";
+    private const string RegexPattern =
+        """
+        (^|[^A-Za-z0-9+\/\-_])([A-Za-z0-9\-_]{24}QJJQB|[A-Za-z0-9\-_]{44}QJJQC|[A-Za-z0-9\-_]{64}QJJQD|[A-Za-z0-9\-_]{88}QJJQE)(A[A-Za-z0-9\-_][A-L][A-Za-e][A-X][A-Za-z0-7][A-Za-z0-9\-_][A-Za-z0-9\-_]{24}|B[A-Za-z0-9\-_][A-L][A-Za-e][A-X][A-Za-z0-7][A-Za-z0-9\-_][A-Za-z0-9\-_]{28}|C[A-Za-z0-9\-_][A-L][A-Za-e][A-X][A-Za-z0-7][A-Za-z0-9\-_][A-Za-z0-9\-_]{32}|D[A-Za-z0-9\-_][A-L][A-Za-e][A-X][A-Za-z0-7][A-Za-z0-9\-_][A-Za-z0-9\-_]{36}|E[A-Za-z0-9\-_][A-L][A-Za-e][A-X][A-Za-z0-7][A-Za-z0-9\-_][A-Za-z0-9\-_]{40})([^A-Za-z0-9+\/\-_]|$)
+        """;
     private const RegexOptions RegexFlags = RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant;
 
     [GeneratedRegex(RegexPattern, RegexFlags)]

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -35,14 +35,14 @@ internal static partial class InternalConstants
     /// The number of bytes used to express year, month, day, and hour
     /// components of the key allocation timestamp.
     /// </summary>
-    public const int YearMonthDayHourSizeInBytes = 3;
+    public const int SecretAndOptionalDataLengthsYearAndMonthSizeInBytes = 3;
 
     /// <summary>
     /// The number of bytes used to express the minutes component of the key
     /// allocation timestamp, the sensitive data size, the optional provider
     /// data size, and the provider key kind.
     /// </summary>
-    public const int MinuteSizesAndKeyKindSizeInBytes = 3;
+    public const int DayHourMinutesAndKeyKindSizeInBytes = 3;
 
     /// <summary>
     /// The number of bytes in a provider signature.
@@ -84,13 +84,4 @@ internal static partial class InternalConstants
     /// The maximum amount of bytes that the implementation will stackalloc.
     /// </summary>
     public const int MaxStackAlloc = 256;
-
-    /// <summary>
-    /// The integer offset (9) of the sensitive data size relative to the
-    /// starting index of the Cask signature in a base64-encoded secret. This
-    /// value consists of the length of the CASK signature and the length of the
-    /// encoded timestamp (which dedicates a character to a year, month, day,
-    /// hour and minute component).
-    /// </summary>
-    public static int SecretSizeOffsetFromCaskSignatureOffset => CaskSignature.Length + "YMDHM".Length;
 }

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -35,14 +35,26 @@ internal static partial class InternalConstants
     /// The number of bytes used to express year, month, day, and hour
     /// components of the key allocation timestamp.
     /// </summary>
-    public const int SecretAndOptionalDataLengthsYearAndMonthSizeInBytes = 3;
+    public const int DataLengthsYearMonthSizeInBytes = 3;
 
     /// <summary>
-    /// The number of bytes used to express the minutes component of the key
-    /// allocation timestamp, the sensitive data size, the optional provider
-    /// data size, and the provider key kind.
+    /// The number of base64-encoded chars used to express year, month, day, and
+    /// hour components of the key allocation timestamp.
     /// </summary>
-    public const int DayHourMinutesAndKeyKindSizeInBytes = 3;
+    public static readonly int DataLengthsYearMonthSizeInChars = BytesToBase64Chars(DataLengthsYearMonthSizeInBytes);
+
+    /// <summary>
+    /// The number of bytes used to express the day, hour and minutes component
+    /// of the key allocation timestamp, and the provider key kind.
+    /// </summary>
+    public const int DayHourMinutesKeyKindSizeInBytes = 3;
+
+    /// <summary>
+    /// The number of base64-encoded chars used to express the day, hour and
+    /// minutes component of the key allocation timestamp, and the provider key
+    /// kind.
+    /// </summary>
+    public static readonly int DayHourMinutesKeyKindSizeInChars = BytesToBase64Chars(DayHourMinutesKeyKindSizeInBytes);
 
     /// <summary>
     /// The number of bytes in a provider signature.
@@ -50,12 +62,12 @@ internal static partial class InternalConstants
     public const int ProviderSignatureSizeInBytes = 3;
 
     /// <summary>
-    /// The number of bytes per encoded secret size chunk.
+    /// The number of bytes per secret size chunk.
     /// </summary>
     public const int SecretChunkSizeInBytes = 16;
 
     /// <summary>
-    /// The number of bytes per encoded optional data size chunk.
+    /// The number of bytes per optional data size chunk.
     /// </summary>
     public const int OptionalDataChunkSizeInBytes = 3;
 

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -35,26 +35,13 @@ internal static partial class InternalConstants
     /// The number of bytes used to express year, month, day, and hour
     /// components of the key allocation timestamp.
     /// </summary>
-    public const int DataLengthsYearMonthSizeInBytes = 3;
+    public const int DataLengthsTimeStampProviderKeyKindSizeInBytes = 6;
 
     /// <summary>
     /// The number of base64-encoded chars used to express year, month, day, and
     /// hour components of the key allocation timestamp.
     /// </summary>
-    public static readonly int DataLengthsYearMonthSizeInChars = BytesToBase64Chars(DataLengthsYearMonthSizeInBytes);
-
-    /// <summary>
-    /// The number of bytes used to express the day, hour and minutes component
-    /// of the key allocation timestamp, and the provider key kind.
-    /// </summary>
-    public const int DayHourMinutesKeyKindSizeInBytes = 3;
-
-    /// <summary>
-    /// The number of base64-encoded chars used to express the day, hour and
-    /// minutes component of the key allocation timestamp, and the provider key
-    /// kind.
-    /// </summary>
-    public static readonly int DayHourMinutesKeyKindSizeInChars = BytesToBase64Chars(DayHourMinutesKeyKindSizeInBytes);
+    public static readonly int DataLengthsTimeStampProviderKeyKindSizeInChars = BytesToBase64Chars(DataLengthsYearMonthSizeInBytes);
 
     /// <summary>
     /// The number of bytes in a provider signature.

--- a/src/Cask/InternalConstants.cs
+++ b/src/Cask/InternalConstants.cs
@@ -41,7 +41,7 @@ internal static partial class InternalConstants
     /// The number of base64-encoded chars used to express year, month, day, and
     /// hour components of the key allocation timestamp.
     /// </summary>
-    public static readonly int DataLengthsTimeStampProviderKeyKindSizeInChars = BytesToBase64Chars(DataLengthsYearMonthSizeInBytes);
+    public static readonly int DataLengthsTimeStampProviderKeyKindSizeInChars = BytesToBase64Chars(DataLengthsTimeStampProviderKeyKindSizeInBytes);
 
     /// <summary>
     /// The number of bytes in a provider signature.

--- a/src/Tests/Cask.Tests/CSharpCaskTests.cs
+++ b/src/Tests/Cask.Tests/CSharpCaskTests.cs
@@ -41,9 +41,9 @@ public class CSharpCaskTests : CaskTestsBase
             }
             catch (FormatException)
             {
-                // On receiving this exception, we have invalid base64 input.
-                // As a result, we will skip the IsCaskBytes check, which
-                // will throw for this condition.
+                // On receiving this exception, we have invalid base64 input. As
+                // a result, we will skip the IsCaskBytes check, which throws
+                // for this condition.
             }
 
             if (key.Any((c) => !s_printableBase64UrlCharacters.Contains(c)))

--- a/src/Tests/Cask.Tests/CaskKeyTests.cs
+++ b/src/Tests/Cask.Tests/CaskKeyTests.cs
@@ -185,7 +185,7 @@ public class CaskKeyTests
 
         Span<char> keyChars = key.ToString().ToCharArray().AsSpan();
 
-        int secretSizeCharOffset = 53;
+        int secretSizeCharOffset = 48;
         var secretSize = (SecretSize)(keyChars[secretSizeCharOffset] - 'A');
 
         Assert.Equal(SecretSize.Bits256, secretSize);


### PR DESCRIPTION
This PR establishes a new ordering of the raw 6-byte sequence that incorporates the timestamp, sensitive data size, optional data size, and provider key kind. Previously the timestamp preceded all other data, so the practical description of the required change is to move this data to precede the provider kind (leaving the sensitive data and optional data sizes in the same order and now immediately following the CASK signature).

#46 includes the detailed rationale for the change). Each encoded character (of which there are 8) in this base64-encoded sequence is interpreted independently, as follows and now in the following order:

1. Secret data size
2. Optional data size
3. Timestamp (viz., time-of-key-allocation) year
4. Timestamp  month
5. Timestamp  day
6. Timestamp  hour
7. Timestamp  minute
8. Provider key kind.

In addition to updating the BNF, pseudocode and API logic, this change adds several missing tests to validate that illegal timestamp values are not accepted as valid.

This change resolves #46 and #45. I have also opportunistically continued to implement our destination `Span` pattern for accessing data (in places not already covered by #49).
