### PR TITLE
Target netstandard2.0 instead of net472, remove System.IO.Hashing dependency

### DIFF
--- a/src/Cask/Cask.csproj
+++ b/src/Cask/Cask.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
@@ -9,7 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Hashing" />
     <PackageReference Include="Microsoft.Bcl.Memory" />
   </ItemGroup>
 

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="9.0.0" />
-    <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup Label="Global Build-Only Dependencies">
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />


### PR DESCRIPTION
The library compiles fine for netstandard2.0 now, so use that in place of net472. Benchmarks and tests still use net472 to exercise the netstandard2.0 compilation. This aligns with https://github.com/security-utilities, which will make it easier to move code between these repos.

Also remove the System.IO.Hashing that we no longer use.