### PR TITLE
Make IsCask and IsCaskUtf8 implementations consistent

### DIFF
--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -23,34 +23,35 @@ public static class Cask
     }
 
     /// <summary>
-    /// Validates that the provided UTF16-encoded text represents a valid Cask key.
+    /// Validates that the provided UTF16-encoded text represents a valid
+    /// base64url-encoded CASK key.
     /// </summary>
-    public static bool IsCask(ReadOnlySpan<char> key)
+    public static bool IsCask(ReadOnlySpan<char> encodedKey)
     {
-        if (!IsValidKeyLengthInChars(key.Length))
+        if (!IsValidKeyLengthInChars(encodedKey.Length))
         {
             return false;
         }
 
-        Range caskSignatureCharRange = ComputeCaskSignatureCharRange(key.Length, out SecretSize _);
+        Range caskSignatureCharRange = ComputeCaskSignatureCharRange(encodedKey.Length, out SecretSize _);
 
         // Check for CASK signature, "QJJQ".
-        if (!key[caskSignatureCharRange].SequenceEqual(CaskSignature))
+        if (!encodedKey[caskSignatureCharRange].SequenceEqual(CaskSignature))
         {
             return false;
         }
 
-        int lengthInBytes = Base64CharsToBytes(key.Length);
+        int lengthInBytes = Base64CharsToBytes(encodedKey.Length);
         Debug.Assert(lengthInBytes <= MaxKeyLengthInBytes);
         Span<byte> keyBytes = stackalloc byte[lengthInBytes];
 
-        OperationStatus status = Base64Url.DecodeFromChars(key,
+        OperationStatus status = Base64Url.DecodeFromChars(encodedKey,
                                                            keyBytes,
                                                            out int charsConsumed,
                                                            out int bytesWritten,
                                                            isFinalBlock: true);
 
-        Debug.Assert(status is OperationStatus.InvalidData || charsConsumed == key.Length);
+        Debug.Assert(status is OperationStatus.InvalidData || charsConsumed == encodedKey.Length);
         Debug.Assert(status is not OperationStatus.DestinationTooSmall or OperationStatus.NeedMoreData);
 
         // NOTE: Decoding can succeed with `bytesWritten < lengthInBytes` if the
@@ -64,34 +65,35 @@ public static class Cask
     }
 
     /// <summary>
-    /// Validates that the provided UTF8-encoded text represents a valid Cask key.
+    /// Validates that the provided UTF8-encoded text represents a valid
+    /// base64url-encoded CASK key.
     /// </summary>
-    public static bool IsCaskUtf8(ReadOnlySpan<byte> keyUtf8)
+    public static bool IsCaskUtf8(ReadOnlySpan<byte> encodedKey)
     {
-        if (!IsValidKeyLengthInChars(keyUtf8.Length))
+        if (!IsValidKeyLengthInChars(encodedKey.Length))
         {
             return false;
         }
 
-        Range caskSignatureCharRange = ComputeCaskSignatureCharRange(keyUtf8.Length, out SecretSize _);
+        Range caskSignatureCharRange = ComputeCaskSignatureCharRange(encodedKey.Length, out SecretSize _);
 
         // Check for CASK signature, "QJJQ".
-        if (!keyUtf8[caskSignatureCharRange].SequenceEqual(CaskSignatureUtf8))
+        if (!encodedKey[caskSignatureCharRange].SequenceEqual(CaskSignatureUtf8))
         {
             return false;
         }
 
-        int lengthInBytes = Base64CharsToBytes(keyUtf8.Length);
+        int lengthInBytes = Base64CharsToBytes(encodedKey.Length);
         Debug.Assert(lengthInBytes <= MaxKeyLengthInBytes);
         Span<byte> keyBytes = stackalloc byte[lengthInBytes];
 
-        OperationStatus status = Base64Url.DecodeFromUtf8(keyUtf8,
+        OperationStatus status = Base64Url.DecodeFromUtf8(encodedKey,
                                                           keyBytes,
                                                           out int charsConsumed,
                                                           out int bytesWritten,
                                                           isFinalBlock: true);
 
-        Debug.Assert(status is OperationStatus.InvalidData || charsConsumed == keyUtf8.Length);
+        Debug.Assert(status is OperationStatus.InvalidData || charsConsumed == encodedKey.Length);
         Debug.Assert(status is not OperationStatus.DestinationTooSmall or OperationStatus.NeedMoreData);
 
         // NOTE: Decoding can succeed with `bytesWritten < lengthInBytes` if the

--- a/src/Cask/Cask.cs
+++ b/src/Cask/Cask.cs
@@ -23,10 +23,8 @@ public static class Cask
     }
 
     /// <summary>
-    /// Validates that the provided UTF16-encoded text sequence represents a
-    /// valid Cask key.
+    /// Validates that the provided UTF16-encoded text represents a valid Cask key.
     /// </summary>
-    /// <param name="key"></param>
     public static bool IsCask(ReadOnlySpan<char> key)
     {
         if (!IsValidKeyLengthInChars(key.Length))
@@ -34,11 +32,7 @@ public static class Cask
             return false;
         }
 
-        SecretSize secretSize = ExtractSecretSizeFromKeyChars(key, out Range caskSignatureCharRange);
-        if (secretSize < SecretSize.Bits128 || secretSize > SecretSize.Bits512)
-        {
-            return false;
-        }
+        Range caskSignatureCharRange = ComputeCaskSignatureCharRange(key.Length, out SecretSize _);
 
         // Check for CASK signature, "QJJQ".
         if (!key[caskSignatureCharRange].SequenceEqual(CaskSignature))
@@ -69,9 +63,8 @@ public static class Cask
         return IsCaskBytes(keyBytes);
     }
 
-
     /// <summary>
-    /// Validates that the provided UTF8-encoded byte sequence represents a valid Cask key.
+    /// Validates that the provided UTF8-encoded text represents a valid Cask key.
     /// </summary>
     public static bool IsCaskUtf8(ReadOnlySpan<byte> keyUtf8)
     {


### PR DESCRIPTION
`IsCask` taking UTF-16 validated the secret size up-front while `IsCaskUtf8` deferred to `IsCaskBytes` to do so. I noticed this discrepancy while looking at #64 where I am experimenting with tricks for sharing code between UTF-8 and UTF-16 cases.

The fix here is to let `IsCaskBytes` handle it in both cases, which is consistent with several other fields that are only validated after decoding to bytes.

This change also moves `IsCaskUtf8` next to `IsCask` to emphasize that these are the same operation for different encodings, to make it easier to look for unwanted differences between them, and to keep public API above helpers.

Finally, parameter names and method documentation are updated to help communication the distinction between the binary decoded form and the base64url-encoded textual forms.
